### PR TITLE
Refactor QuizService and separate caching logic

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -154,8 +154,12 @@ func main() {
 	cacheAdapter := adapter.NewRedisCacheAdapter(redisClient)
 	log.Info("RedisCacheAdapter initialized", zap.String("adapter_type", "RedisCacheAdapter")) // Optional: for confirmation
 
+	// Initialize AnswerCacheService
+	answerCacheService := service.NewAnswerCacheService(cacheAdapter, domainRepo, cfg)
+	log.Info("AnswerCacheService initialized")
+
 	// Initialize service
-	svc := service.NewQuizService(domainRepo, evaluator, cacheAdapter, cfg, embeddingService)
+	svc := service.NewQuizService(domainRepo, evaluator, cacheAdapter, cfg, embeddingService, answerCacheService)
 
 	// Initialize handler
 	handler := handler.NewQuizHandler(svc)

--- a/internal/service/answer_cache.go
+++ b/internal/service/answer_cache.go
@@ -1,0 +1,187 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"time"
+
+	"quiz-byte/internal/config"
+	"quiz-byte/internal/domain"
+	"quiz-byte/internal/dto"
+	"quiz-byte/internal/logger"
+	"quiz-byte/internal/util" // For CosineSimilarity
+
+	"go.uber.org/zap"
+)
+
+const (
+	AnswerCachePrefix     = "quizanswers:"
+	AnswerCacheExpiration = 24 * time.Hour
+)
+
+// CachedAnswerEvaluation defines the structure for cached answer evaluations including embeddings
+type CachedAnswerEvaluation struct {
+	Evaluation *dto.CheckAnswerResponse `json:"evaluation"`
+	Embedding  []float32                `json:"embedding"`
+	UserAnswer string                   `json:"user_answer,omitempty"` // For debugging/logging
+}
+
+// AnswerCacheService defines the interface for answer caching operations
+type AnswerCacheService interface {
+	GetAnswerFromCache(ctx context.Context, quizID string, userAnswerEmbedding []float32, userAnswerText string) (*dto.CheckAnswerResponse, error)
+	PutAnswerToCache(ctx context.Context, quizID string, userAnswerText string, userAnswerEmbedding []float32, evaluation *dto.CheckAnswerResponse) error
+}
+
+// answerCacheServiceImpl implements AnswerCacheService
+type answerCacheServiceImpl struct {
+	cache domain.Cache
+	repo  domain.QuizRepository
+	cfg   *config.Config
+}
+
+// NewAnswerCacheService creates a new instance of answerCacheServiceImpl
+func NewAnswerCacheService(cache domain.Cache, repo domain.QuizRepository, cfg *config.Config) AnswerCacheService {
+	// Handle nil cache gracefully in the service methods if it can be nil.
+	// Or ensure it's never nil when NewAnswerCacheService is called.
+	// For now, assume it's a valid instance.
+	return &answerCacheServiceImpl{
+		cache: cache,
+		repo:  repo,
+		cfg:   cfg,
+	}
+}
+
+// GetAnswerFromCache retrieves an answer from the cache if a similar one exists.
+func (s *answerCacheServiceImpl) GetAnswerFromCache(ctx context.Context, quizID string, userAnswerEmbedding []float32, userAnswerText string) (*dto.CheckAnswerResponse, error) {
+	if s.cache == nil || s.cfg == nil { // Or s.cfg.Embedding.SimilarityThreshold == 0 if that's a disabled state
+		logger.Get().Debug("AnswerCacheService: Cache or config not available, skipping cache lookup.", zap.String("quizID", quizID))
+		return nil, nil // Not an error, just no cache service available
+	}
+	if len(userAnswerEmbedding) == 0 { // Should not happen if called correctly, but good check
+		logger.Get().Warn("AnswerCacheService: GetAnswerFromCache called with empty userAnswerEmbedding", zap.String("quizID", quizID))
+		return nil, nil
+	}
+
+
+	cacheKey := AnswerCachePrefix + quizID
+	cachedAnswersMap, err := s.cache.HGetAll(ctx, cacheKey)
+	if err != nil {
+		if err == domain.ErrCacheMiss { // HGetAll might return this if key doesn't exist (depends on impl)
+			logger.Get().Debug("AnswerCacheService: Cache miss (key not found)", zap.String("key", cacheKey), zap.String("quizID", quizID))
+			return nil, nil
+		}
+		logger.Get().Error("AnswerCacheService: Cache HGetAll failed", zap.Error(err), zap.String("key", cacheKey), zap.String("quizID", quizID))
+		return nil, err // Actual cache error
+	}
+
+	if len(cachedAnswersMap) == 0 {
+		logger.Get().Debug("AnswerCacheService: Cache miss (empty map)", zap.String("key", cacheKey), zap.String("quizID", quizID))
+		return nil, nil
+	}
+
+	for _, cachedEvalDataStr := range cachedAnswersMap {
+		var cachedEntry CachedAnswerEvaluation
+		if errUnmarshal := json.Unmarshal([]byte(cachedEvalDataStr), &cachedEntry); errUnmarshal != nil {
+			logger.Get().Warn("AnswerCacheService: Failed to unmarshal cached answer evaluation",
+				zap.Error(errUnmarshal),
+				zap.String("quizID", quizID),
+				zap.String("userAnswer", userAnswerText))
+			continue // Skip this entry
+		}
+
+		if len(cachedEntry.Embedding) == 0 {
+			logger.Get().Debug("AnswerCacheService: Skipping cached entry due to missing embedding",
+				zap.String("quizID", quizID),
+				zap.String("cachedUserAnswer", cachedEntry.UserAnswer),
+				zap.String("userAnswer", userAnswerText))
+			continue // Skip this entry
+		}
+
+		similarity, errSim := util.CosineSimilarity(userAnswerEmbedding, cachedEntry.Embedding)
+		if errSim != nil {
+			logger.Get().Warn("AnswerCacheService: Failed to calculate cosine similarity for cached answer",
+				zap.Error(errSim),
+				zap.String("quizID", quizID),
+				zap.String("userAnswer", userAnswerText))
+			continue // Skip this entry
+		}
+
+		if similarity >= s.cfg.Embedding.SimilarityThreshold {
+			logger.Get().Info("AnswerCacheService: Cache hit - Found similar answer",
+				zap.String("quizID", quizID),
+				zap.String("userAnswer", userAnswerText),
+				zap.Float64("similarity", similarity),
+				zap.String("cachedUserAnswer", cachedEntry.UserAnswer))
+
+			// Update model answer from latest quiz data
+			if s.repo != nil { // Ensure repo is available
+				quizForModelAnswer, errRepo := s.repo.GetQuizByID(quizID)
+				if errRepo != nil {
+					logger.Get().Error("AnswerCacheService: Failed to get quiz by ID for updating model answer in cache hit",
+						zap.Error(errRepo),
+						zap.String("quizID", quizID))
+					// Return the cached evaluation anyway, as updating model answer is an enhancement
+				} else if quizForModelAnswer != nil {
+					cachedEntry.Evaluation.ModelAnswer = strings.Join(quizForModelAnswer.ModelAnswers, "\n")
+				}
+			}
+			return cachedEntry.Evaluation, nil // Cache Hit
+		}
+	}
+
+	logger.Get().Debug("AnswerCacheService: No sufficiently similar answer found in cache", zap.String("quizID", quizID), zap.String("userAnswer", userAnswerText))
+	return nil, nil // Cache Miss (no similar answer found)
+}
+
+// PutAnswerToCache puts an answer evaluation into the cache.
+func (s *answerCacheServiceImpl) PutAnswerToCache(ctx context.Context, quizID string, userAnswerText string, userAnswerEmbedding []float32, evaluation *dto.CheckAnswerResponse) error {
+	if s.cache == nil {
+		logger.Get().Debug("AnswerCacheService: Cache not available, skipping cache write.", zap.String("quizID", quizID))
+		return nil // Not an error, just no cache service available
+	}
+	if len(userAnswerEmbedding) == 0 { // Should not happen if called correctly
+		logger.Get().Warn("AnswerCacheService: PutAnswerToCache called with empty userAnswerEmbedding, not caching.", zap.String("quizID", quizID))
+		return nil // Don't cache if embedding is missing
+	}
+	if evaluation == nil {
+		logger.Get().Warn("AnswerCacheService: PutAnswerToCache called with nil evaluation, not caching.", zap.String("quizID", quizID))
+		return nil
+	}
+
+	cacheKey := AnswerCachePrefix + quizID
+	cachedEval := CachedAnswerEvaluation{
+		Evaluation: evaluation,
+		Embedding:  userAnswerEmbedding,
+		UserAnswer: userAnswerText,
+	}
+
+	cachedJSON, errMarshal := json.Marshal(cachedEval)
+	if errMarshal != nil {
+		logger.Get().Error("AnswerCacheService: Failed to marshal answer evaluation for caching",
+			zap.Error(errMarshal),
+			zap.String("quizID", quizID))
+		return errMarshal // Return the error
+	}
+
+	if err := s.cache.HSet(ctx, cacheKey, userAnswerText, string(cachedJSON)); err != nil {
+		logger.Get().Error("AnswerCacheService: Failed to cache answer evaluation (HSet)",
+			zap.Error(err),
+			zap.String("quizID", quizID))
+		return err
+	}
+
+	if err := s.cache.Expire(ctx, cacheKey, AnswerCacheExpiration); err != nil {
+		logger.Get().Error("AnswerCacheService: Failed to set cache expiration",
+			zap.Error(err),
+			zap.String("quizID", quizID))
+		return err // Return the error, even if HSet succeeded.
+	}
+
+	logger.Get().Info("AnswerCacheService: Answer evaluation and embedding cached successfully",
+		zap.String("quizID", quizID),
+		zap.String("userAnswer", userAnswerText))
+	return nil
+}
+
+[end of internal/service/answer_cache.go]

--- a/internal/service/answer_cache_test.go
+++ b/internal/service/answer_cache_test.go
@@ -1,0 +1,381 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"quiz-byte/internal/config"
+	"quiz-byte/internal/domain"
+	"quiz-byte/internal/dto"
+	"quiz-byte/internal/logger"
+	// util is needed for CosineSimilarity, but it's called by the service, not directly by the test usually.
+	// "quiz-byte/internal/util"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+// TestMain for logger initialization
+func TestMain(m *testing.M) {
+	cfg := &config.Config{}
+	if err := logger.Initialize(cfg); err != nil {
+		panic("Failed to initialize logger for tests: " + err.Error())
+	}
+	exitVal := m.Run()
+	_ = logger.Sync()
+	os.Exit(exitVal)
+}
+
+// --- Mocks for AnswerCacheService Tests ---
+
+type MockAnswerCacheDomainCache struct {
+	mock.Mock
+}
+
+func (m *MockAnswerCacheDomainCache) HGetAll(ctx context.Context, key string) (map[string]string, error) {
+	args := m.Called(ctx, key)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(map[string]string), args.Error(1)
+}
+
+func (m *MockAnswerCacheDomainCache) HSet(ctx context.Context, key string, field string, value string) error {
+	args := m.Called(ctx, key, field, value)
+	return args.Error(0)
+}
+
+func (m *MockAnswerCacheDomainCache) Expire(ctx context.Context, key string, expiration time.Duration) error {
+	args := m.Called(ctx, key, expiration)
+	return args.Error(0)
+}
+
+// Get, Set, Delete, Ping, HGet are not used by AnswerCacheService, so not mocked here.
+
+type MockAnswerCacheQuizRepository struct {
+	mock.Mock
+}
+
+func (m *MockAnswerCacheQuizRepository) GetQuizByID(id string) (*domain.Quiz, error) {
+	args := m.Called(id)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*domain.Quiz), args.Error(1)
+}
+
+// Other repository methods are not used by AnswerCacheService.
+
+// --- Tests for AnswerCacheService ---
+
+func TestAnswerCacheServiceImpl_GetAnswerFromCache(t *testing.T) {
+	ctx := context.Background()
+	baseQuizID := "quizGet123"
+	baseUserAnswerText := "test user answer for get"
+	baseUserAnswerEmbedding := []float32{0.1, 0.2, 0.3}
+
+	cfg := &config.Config{
+		Embedding: config.EmbeddingConfig{
+			SimilarityThreshold: 0.9,
+		},
+	}
+
+	t.Run("Cache Hit - High Similarity", func(t *testing.T) {
+		mockCache := new(MockAnswerCacheDomainCache)
+		mockRepo := new(MockAnswerCacheQuizRepository)
+		service := NewAnswerCacheService(mockCache, mockRepo, cfg)
+
+		cacheKey := AnswerCachePrefix + baseQuizID
+		similarEmbedding := []float32{0.11, 0.21, 0.31} // Similar
+		expectedEvalResponse := &dto.CheckAnswerResponse{Score: 0.85, Explanation: "Cached explanation", ModelAnswer: "Original Model Ans"}
+		cachedData := CachedAnswerEvaluation{
+			Evaluation: expectedEvalResponse,
+			Embedding:  similarEmbedding,
+			UserAnswer: "similar cached text",
+		}
+		marshaledCachedData, _ := json.Marshal(cachedData)
+		cacheReturnMap := map[string]string{cachedData.UserAnswer: string(marshaledCachedData)}
+
+		mockCache.On("HGetAll", ctx, cacheKey).Return(cacheReturnMap, nil).Once()
+		updatedModelAnswer := "Updated Model Answer For Cache Hit"
+		mockRepo.On("GetQuizByID", baseQuizID).Return(&domain.Quiz{ModelAnswers: []string{updatedModelAnswer}}, nil).Once()
+
+		response, err := service.GetAnswerFromCache(ctx, baseQuizID, baseUserAnswerEmbedding, baseUserAnswerText)
+
+		assert.NoError(t, err)
+		assert.NotNil(t, response)
+		assert.Equal(t, expectedEvalResponse.Score, response.Score)
+		assert.Equal(t, updatedModelAnswer, response.ModelAnswer) // Check model answer update
+		mockCache.AssertExpectations(t)
+		mockRepo.AssertExpectations(t)
+	})
+
+	t.Run("Cache Hit - Low Similarity", func(t *testing.T) {
+		mockCache := new(MockAnswerCacheDomainCache)
+		mockRepo := new(MockAnswerCacheQuizRepository)
+		service := NewAnswerCacheService(mockCache, mockRepo, cfg)
+
+		cacheKey := AnswerCachePrefix + baseQuizID
+		dissimilarEmbedding := []float32{0.9, 0.8, 0.7} // Dissimilar
+		cachedEvalResponse := &dto.CheckAnswerResponse{Score: 0.30, Explanation: "Dissimilar cached explanation"}
+		cachedData := CachedAnswerEvaluation{
+			Evaluation: cachedEvalResponse,
+			Embedding:  dissimilarEmbedding,
+			UserAnswer: "dissimilar cached text",
+		}
+		marshaledCachedData, _ := json.Marshal(cachedData)
+		cacheReturnMap := map[string]string{cachedData.UserAnswer: string(marshaledCachedData)}
+
+		mockCache.On("HGetAll", ctx, cacheKey).Return(cacheReturnMap, nil).Once()
+
+		response, err := service.GetAnswerFromCache(ctx, baseQuizID, baseUserAnswerEmbedding, baseUserAnswerText)
+
+		assert.NoError(t, err)
+		assert.Nil(t, response) // Cache miss due to low similarity
+		mockCache.AssertExpectations(t)
+		mockRepo.AssertNotCalled(t, "GetQuizByID")
+	})
+
+	t.Run("Cache Miss - Empty Cache", func(t *testing.T) {
+		mockCache := new(MockAnswerCacheDomainCache)
+		mockRepo := new(MockAnswerCacheQuizRepository)
+		service := NewAnswerCacheService(mockCache, mockRepo, cfg)
+		cacheKey := AnswerCachePrefix + baseQuizID
+
+		mockCache.On("HGetAll", ctx, cacheKey).Return(map[string]string{}, nil).Once()
+
+		response, err := service.GetAnswerFromCache(ctx, baseQuizID, baseUserAnswerEmbedding, baseUserAnswerText)
+		assert.NoError(t, err)
+		assert.Nil(t, response)
+		mockCache.AssertExpectations(t)
+		mockRepo.AssertNotCalled(t, "GetQuizByID")
+	})
+
+	t.Run("Cache Miss - CacheKey Not Found (ErrCacheMiss)", func(t *testing.T) {
+		mockCache := new(MockAnswerCacheDomainCache)
+		mockRepo := new(MockAnswerCacheQuizRepository)
+		service := NewAnswerCacheService(mockCache, mockRepo, cfg)
+		cacheKey := AnswerCachePrefix + baseQuizID
+
+		mockCache.On("HGetAll", ctx, cacheKey).Return(nil, domain.ErrCacheMiss).Once()
+
+		response, err := service.GetAnswerFromCache(ctx, baseQuizID, baseUserAnswerEmbedding, baseUserAnswerText)
+		assert.NoError(t, err)
+		assert.Nil(t, response)
+		mockCache.AssertExpectations(t)
+		mockRepo.AssertNotCalled(t, "GetQuizByID")
+	})
+
+
+	t.Run("Cache Error on HGetAll", func(t *testing.T) {
+		mockCache := new(MockAnswerCacheDomainCache)
+		mockRepo := new(MockAnswerCacheQuizRepository)
+		service := NewAnswerCacheService(mockCache, mockRepo, cfg)
+		cacheKey := AnswerCachePrefix + baseQuizID
+		expectedError := fmt.Errorf("HGetAll failed")
+
+		mockCache.On("HGetAll", ctx, cacheKey).Return(nil, expectedError).Once()
+
+		response, err := service.GetAnswerFromCache(ctx, baseQuizID, baseUserAnswerEmbedding, baseUserAnswerText)
+		assert.ErrorIs(t, err, expectedError)
+		assert.Nil(t, response)
+		mockCache.AssertExpectations(t)
+		mockRepo.AssertNotCalled(t, "GetQuizByID")
+	})
+
+	t.Run("Unmarshal Error for a cached entry", func(t *testing.T) {
+		mockCache := new(MockAnswerCacheDomainCache)
+		mockRepo := new(MockAnswerCacheQuizRepository)
+		service := NewAnswerCacheService(mockCache, mockRepo, cfg)
+		cacheKey := AnswerCachePrefix + baseQuizID
+
+		// One valid, one invalid
+		validCachedData := CachedAnswerEvaluation{Evaluation: &dto.CheckAnswerResponse{Score: 0.9}, Embedding: []float32{0.11,0.21,0.31}}
+		marshaledValid, _ := json.Marshal(validCachedData)
+		cacheReturnMap := map[string]string{
+			"validEntry":   string(marshaledValid),
+			"invalidEntry": "this is not json",
+		}
+		// Mock GetQuizByID for the valid entry if it's found and similar
+		mockRepo.On("GetQuizByID", baseQuizID).Return(&domain.Quiz{ModelAnswers: []string{"Updated"}}, nil).Maybe()
+
+
+		mockCache.On("HGetAll", ctx, cacheKey).Return(cacheReturnMap, nil).Once()
+
+		response, err := service.GetAnswerFromCache(ctx, baseQuizID, baseUserAnswerEmbedding, baseUserAnswerText)
+
+		// Depending on the order of iteration, it might find the valid one or skip the invalid one.
+		// If it finds the valid one and it's similar, it returns it.
+		// If the valid one is not similar enough, it returns nil, nil after trying all.
+		// The key is that an unmarshal error for one entry doesn't stop processing of others.
+		assert.NoError(t, err)
+		// If baseUserAnswerEmbedding is similar to validCachedData.Embedding, then response will be non-nil.
+		// For this specific test, let's assume it is similar.
+		assert.NotNil(t, response)
+		assert.Equal(t, validCachedData.Evaluation.Score, response.Score)
+
+		mockCache.AssertExpectations(t)
+		mockRepo.AssertExpectations(t) // GetQuizByID should be called if the valid entry is hit
+	})
+
+	t.Run("GetQuizByID Fails During Model Answer Update", func(t *testing.T) {
+		mockCache := new(MockAnswerCacheDomainCache)
+		mockRepo := new(MockAnswerCacheQuizRepository)
+		service := NewAnswerCacheService(mockCache, mockRepo, cfg)
+
+		cacheKey := AnswerCachePrefix + baseQuizID
+		similarEmbedding := []float32{0.11, 0.21, 0.31}
+		originalModelAnswer := "Original Model From Cache"
+		expectedEvalResponse := &dto.CheckAnswerResponse{Score: 0.85, Explanation: "Cached explanation", ModelAnswer: originalModelAnswer}
+		cachedData := CachedAnswerEvaluation{
+			Evaluation: expectedEvalResponse,
+			Embedding:  similarEmbedding,
+		}
+		marshaledCachedData, _ := json.Marshal(cachedData)
+		cacheReturnMap := map[string]string{"somekey": string(marshaledCachedData)}
+
+		mockCache.On("HGetAll", ctx, cacheKey).Return(cacheReturnMap, nil).Once()
+		repoError := fmt.Errorf("repo GetQuizByID failed")
+		mockRepo.On("GetQuizByID", baseQuizID).Return(nil, repoError).Once()
+
+		response, err := service.GetAnswerFromCache(ctx, baseQuizID, baseUserAnswerEmbedding, baseUserAnswerText)
+
+		assert.NoError(t, err) // The error from GetQuizByID is logged but not returned to QuizService
+		assert.NotNil(t, response)
+		assert.Equal(t, expectedEvalResponse.Score, response.Score)
+		assert.Equal(t, originalModelAnswer, response.ModelAnswer) // ModelAnswer remains original
+		mockCache.AssertExpectations(t)
+		mockRepo.AssertExpectations(t)
+	})
+
+	t.Run("Cache Service disabled (nil cache)", func(t *testing.T) {
+		mockRepo := new(MockAnswerCacheQuizRepository) // Repo might still be non-nil
+		service := NewAnswerCacheService(nil, mockRepo, cfg) // nil cache
+
+		response, err := service.GetAnswerFromCache(ctx, baseQuizID, baseUserAnswerEmbedding, baseUserAnswerText)
+		assert.NoError(t, err)
+		assert.Nil(t, response)
+		mockRepo.AssertNotCalled(t, "GetQuizByID")
+	})
+
+	t.Run("Empty User Answer Embedding", func(t *testing.T) {
+		mockCache := new(MockAnswerCacheDomainCache)
+		mockRepo := new(MockAnswerCacheQuizRepository)
+		service := NewAnswerCacheService(mockCache, mockRepo, cfg)
+
+		response, err := service.GetAnswerFromCache(ctx, baseQuizID, []float32{}, baseUserAnswerText) // Empty embedding
+		assert.NoError(t, err)
+		assert.Nil(t, response)
+		mockCache.AssertNotCalled(t, "HGetAll")
+		mockRepo.AssertNotCalled(t, "GetQuizByID")
+	})
+}
+
+func TestAnswerCacheServiceImpl_PutAnswerToCache(t *testing.T) {
+	ctx := context.Background()
+	baseQuizID := "quizPut123"
+	baseUserAnswerText := "test user answer for put"
+	baseUserAnswerEmbedding := []float32{0.3, 0.2, 0.1}
+	baseEvaluation := &dto.CheckAnswerResponse{
+		Score:       0.9,
+		Explanation: "Great answer!",
+		ModelAnswer: "Model answer for put",
+	}
+	cfg := &config.Config{} // SimilarityThreshold not used in Put
+
+	t.Run("Successful Cache Write", func(t *testing.T) {
+		mockCache := new(MockAnswerCacheDomainCache)
+		// mockRepo is not used by PutAnswerToCache
+		service := NewAnswerCacheService(mockCache, nil, cfg)
+
+		cacheKey := AnswerCachePrefix + baseQuizID
+		expectedCachedEval := CachedAnswerEvaluation{
+			Evaluation: baseEvaluation,
+			Embedding:  baseUserAnswerEmbedding,
+			UserAnswer: baseUserAnswerText,
+		}
+		expectedJSON, _ := json.Marshal(expectedCachedEval)
+
+		mockCache.On("HSet", ctx, cacheKey, baseUserAnswerText, string(expectedJSON)).Return(nil).Once()
+		mockCache.On("Expire", ctx, cacheKey, AnswerCacheExpiration).Return(nil).Once()
+
+		err := service.PutAnswerToCache(ctx, baseQuizID, baseUserAnswerText, baseUserAnswerEmbedding, baseEvaluation)
+		assert.NoError(t, err)
+		mockCache.AssertExpectations(t)
+	})
+
+	t.Run("Cache HSet Fails", func(t *testing.T) {
+		mockCache := new(MockAnswerCacheDomainCache)
+		service := NewAnswerCacheService(mockCache, nil, cfg)
+		cacheKey := AnswerCachePrefix + baseQuizID
+		expectedError := fmt.Errorf("HSet failed")
+
+		// json.Marshal will be called, so ensure args match for HSet
+		expectedCachedEval := CachedAnswerEvaluation{
+			Evaluation: baseEvaluation,
+			Embedding:  baseUserAnswerEmbedding,
+			UserAnswer: baseUserAnswerText,
+		}
+		expectedJSON, _ := json.Marshal(expectedCachedEval)
+
+		mockCache.On("HSet", ctx, cacheKey, baseUserAnswerText, string(expectedJSON)).Return(expectedError).Once()
+
+		err := service.PutAnswerToCache(ctx, baseQuizID, baseUserAnswerText, baseUserAnswerEmbedding, baseEvaluation)
+		assert.ErrorIs(t, err, expectedError)
+		mockCache.AssertExpectations(t)
+		mockCache.AssertNotCalled(t, "Expire") // Expire should not be called if HSet fails
+	})
+
+	t.Run("Cache Expire Fails", func(t *testing.T) {
+		mockCache := new(MockAnswerCacheDomainCache)
+		service := NewAnswerCacheService(mockCache, nil, cfg)
+		cacheKey := AnswerCachePrefix + baseQuizID
+		expectedError := fmt.Errorf("Expire failed")
+
+		expectedCachedEval := CachedAnswerEvaluation{
+			Evaluation: baseEvaluation,
+			Embedding:  baseUserAnswerEmbedding,
+			UserAnswer: baseUserAnswerText,
+		}
+		expectedJSON, _ := json.Marshal(expectedCachedEval)
+
+		mockCache.On("HSet", ctx, cacheKey, baseUserAnswerText, string(expectedJSON)).Return(nil).Once()
+		mockCache.On("Expire", ctx, cacheKey, AnswerCacheExpiration).Return(expectedError).Once()
+
+		err := service.PutAnswerToCache(ctx, baseQuizID, baseUserAnswerText, baseUserAnswerEmbedding, baseEvaluation)
+		assert.ErrorIs(t, err, expectedError)
+		mockCache.AssertExpectations(t)
+	})
+
+	t.Run("Cache Service disabled (nil cache)", func(t *testing.T) {
+		service := NewAnswerCacheService(nil, nil, cfg) // nil cache
+
+		err := service.PutAnswerToCache(ctx, baseQuizID, baseUserAnswerText, baseUserAnswerEmbedding, baseEvaluation)
+		assert.NoError(t, err) // Should not error, just skip
+	})
+
+	t.Run("Empty User Answer Embedding", func(t *testing.T) {
+		mockCache := new(MockAnswerCacheDomainCache)
+		service := NewAnswerCacheService(mockCache, nil, cfg)
+
+		err := service.PutAnswerToCache(ctx, baseQuizID, baseUserAnswerText, []float32{}, baseEvaluation) // Empty embedding
+		assert.NoError(t, err) // Skips caching
+		mockCache.AssertNotCalled(t, "HSet")
+		mockCache.AssertNotCalled(t, "Expire")
+	})
+
+	t.Run("Nil Evaluation", func(t *testing.T) {
+		mockCache := new(MockAnswerCacheDomainCache)
+		service := NewAnswerCacheService(mockCache, nil, cfg)
+
+		err := service.PutAnswerToCache(ctx, baseQuizID, baseUserAnswerText, baseUserAnswerEmbedding, nil) // Nil evaluation
+		assert.NoError(t, err) // Skips caching
+		mockCache.AssertNotCalled(t, "HSet")
+		mockCache.AssertNotCalled(t, "Expire")
+	})
+}
+[end of internal/service/answer_cache_test.go]


### PR DESCRIPTION
This commit addresses two main issues:

1.  **QuizService Responsibility Clarification (Issue 2.1):**
    *   `QuizService` now relies on an injected `EmbeddingService` instance rather than `config.Config` to determine if embedding-related operations (like caching with similarity checks) should be performed.
    *   Optimized embedding generation in `CheckAnswer` to a single call, with the result reused for cache lookups and writes.
    *   Updated `quiz_test.go` to use a `MockEmbeddingService` and reflect these changes.

2.  **Separation of Caching Logic (Issue 2.2):**
    *   Introduced a new `AnswerCacheService` responsible for the detailed logic of reading from and writing answer evaluations to the cache, including embedding similarity checks.
    *   `QuizService` now delegates caching operations to `AnswerCacheService`.
    *   `CachedAnswerEvaluation` struct and related constants moved to `answer_cache.go`.
    *   Added `AnswerCacheService` dependency to `QuizService` and updated `main.go` for its initialization and injection.
    *   Updated `quiz_test.go` to mock `AnswerCacheService`.
    *   Created `answer_cache_test.go` with comprehensive unit tests for the new `AnswerCacheService`.

These changes improve the Single Responsibility Principle for `QuizService`, enhance testability, and make the codebase more modular.