### PR TITLE
refactor: Abstract LLM interaction into QuizGenerationService

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,43 @@
+# Stage 1: Build the Go application
+FROM golang:1.21-alpine AS builder
+
+WORKDIR /app
+
+# Install git for fetching dependencies if needed by go mod
+RUN apk add --no-cache git
+
+# Copy go.mod and go.sum first to leverage Docker cache
+COPY go.mod go.sum ./
+RUN go mod download
+
+# Copy the entire project
+COPY . .
+
+# Build the batch application
+# Adjust the output path if your main.go is elsewhere or you want a specific name
+RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o /app/batch_add_questions ./cmd/batch_add_questions/main.go
+
+# Stage 2: Create the runtime image
+FROM alpine:latest
+
+WORKDIR /app
+
+# Create a non-root user and group for security
+RUN addgroup -S appgroup && adduser -S appuser -G appgroup
+
+# Copy the built binary from the builder stage
+COPY --from=builder /app/batch_add_questions /app/batch_add_questions
+
+# Copy configuration files (if any are needed at runtime and not solely managed by env vars)
+# Assuming config.yaml might be used or serve as a base for env vars.
+# Adjust if your config is purely env-based.
+COPY configs/ /app/configs/
+# Ensure the appuser can read the config if it's file-based
+RUN chown -R appuser:appgroup /app/configs
+
+# Set the user for the container
+USER appuser
+
+# Command to run the application
+# Pass environment variables at runtime (e.g., via Kubernetes CronJob spec or docker run -e)
+ENTRYPOINT ["/app/batch_add_questions"]

--- a/cmd/batch_add_questions/main.go
+++ b/cmd/batch_add_questions/main.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"context"
+	"fmt" // For initial error printing before logger is up
+
+	"github.com/surna/quiz_app/internal/adapter/embedding"
+	"github.com/surna/quiz_app/internal/adapter/quizgen" // Changed from llm to quizgen
+	"github.com/surna/quiz_app/internal/config"
+	"github.com/surna/quiz_app/internal/database"
+	"github.com/surna/quiz_app/internal/domain"
+	"github.com/surna/quiz_app/internal/logger"
+	"github.com/surna/quiz_app/internal/repository"
+	"github.com/surna/quiz_app/internal/service"
+	"go.uber.org/zap"
+)
+
+func main() {
+	// Load configuration
+	cfg, err := config.LoadConfig()
+	if err != nil {
+		// Logger might not be initialized yet, so use fmt for this critical error
+		fmt.Printf("Failed to load configuration: %v\n", err)
+		return // Cannot proceed without config
+	}
+
+	// Initialize logger
+	err = logger.Initialize(cfg) // Corrected initialization
+	if err != nil {
+		fmt.Printf("Failed to initialize logger: %v\n", err)
+		return // Cannot proceed without logger
+	}
+	defer logger.Sync() // Corrected defer
+
+	logger.Get().Info("Batch process starting up...") // Corrected usage
+
+	// Create Oracle DSN
+	dsn := cfg.GetDSN()
+	if dsn == "" {
+		logger.Get().Fatal("Generated DSN is empty. Check DB configuration.")
+	}
+	// Not logging DSN itself for security
+	logger.Get().Info("Successfully generated DSN.")
+
+
+	// Establish DB connection
+	db, err := database.NewSQLXOracleDB(dsn)
+	if err != nil {
+		logger.Get().Fatal("Failed to connect to Oracle database", zap.Error(err))
+	}
+	defer db.Close()
+	logger.Get().Info("Successfully connected to Oracle database.")
+
+	// Initialize Repositories
+	quizRepo := repository.NewQuizDatabaseAdapter(db)
+	categoryRepo := repository.NewCategoryDatabaseAdapter(db) // Assuming this constructor exists
+	logger.Get().Info("Initialized repositories.")
+
+	// Initialize EmbeddingService
+	var embedService domain.EmbeddingService
+	switch cfg.Embedding.Source {
+	case "openai":
+		if cfg.Embedding.OpenAI.APIKey == "" {
+			logger.Get().Fatal("OpenAI API key is not configured.")
+		}
+		embedService, err = embedding.NewOpenAIEmbeddingService(cfg.Embedding.OpenAI.APIKey, cfg.Embedding.OpenAI.Model)
+		if err != nil {
+			logger.Get().Fatal("Failed to initialize OpenAI Embedding Service", zap.Error(err))
+		}
+		logger.Get().Info("Initialized OpenAI Embedding Service.")
+	// Add other cases for "ollama" or other sources if needed
+	default:
+		logger.Get().Fatal("Unsupported embedding source specified in configuration", zap.String("source", cfg.Embedding.Source))
+	}
+
+	// Initialize LLM Client
+	if cfg.Gemini.APIKey == "" {
+		logger.Get().Fatal("Gemini API key is not configured.")
+	}
+	// Initialize the new QuizGenerator
+	quizGenerator, err := quizgen.NewGeminiQuizGenerator(cfg.Gemini.APIKey, cfg.Gemini.Model, logger.Get())
+	if err != nil {
+		logger.Get().Fatal("Failed to initialize QuizGenerator", zap.Error(err))
+	}
+	logger.Get().Info("Initialized QuizGenerator (Gemini).")
+
+	// Initialize BatchService
+	batchSvc := service.NewBatchService(quizRepo, categoryRepo, embedService, quizGenerator, cfg, logger.Get())
+	logger.Get().Info("Initialized Batch Service.")
+
+	// Create a context for the batch process
+	ctx := context.Background()
+
+	// Call GenerateNewQuizzesAndSave
+	logger.Get().Info("Starting quiz generation and saving process...")
+	err = batchSvc.GenerateNewQuizzesAndSave(ctx)
+	if err != nil {
+		logger.Get().Fatal("Batch process failed", zap.Error(err))
+	}
+
+	logger.Get().Info("Batch process completed successfully.")
+}

--- a/internal/adapter/quizgen/gemini_quiz_generator.go
+++ b/internal/adapter/quizgen/gemini_quiz_generator.go
@@ -1,0 +1,124 @@
+package quizgen
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings" // For building the prompt
+
+	"github.com/surna/quiz_app/internal/domain"
+	"go.uber.org/zap" // For logging the prompt
+)
+
+// GeminiQuizGenerator implements the domain.QuizGenerationService interface using a conceptual LangchainGo client.
+type GeminiQuizGenerator struct {
+	// In a real scenario, this would be the LangchainGo Gemini client instance.
+	// For example: client *gemini.GenerativeModel (or whatever the specific type is)
+	langchainClient interface{}
+	apiKey          string
+	modelName       string
+	logger          *zap.Logger
+}
+
+// NewGeminiQuizGenerator creates a new instance of GeminiQuizGenerator.
+// The actual LangchainGo client initialization would happen here.
+func NewGeminiQuizGenerator(apiKey string, modelName string, logger *zap.Logger) (domain.QuizGenerationService, error) {
+	if apiKey == "" {
+		return nil, fmt.Errorf("Gemini API key cannot be empty")
+	}
+	if modelName == "" {
+		return nil, fmt.Errorf("Gemini model name cannot be empty")
+	}
+	logger.Info("Initializing GeminiQuizGenerator", zap.String("model", modelName))
+	// Placeholder for actual LangchainGo client init
+	// client := langchain.NewGeminiClient(apiKey, modelName) etc.
+	return &GeminiQuizGenerator{
+		langchainClient: nil, // Placeholder
+		apiKey:          apiKey,
+		modelName:       modelName,
+		logger:          logger,
+	}, nil
+}
+
+// GenerateQuizCandidates constructs a prompt and simulates an LLM call.
+// This method matches the domain.QuizGenerationService interface.
+func (a *GeminiQuizGenerator) GenerateQuizCandidates(ctx context.Context, subCategoryName string, existingKeywords []string, numQuestions int) ([]*domain.NewQuizData, error) {
+	var generatedQuizzes []*domain.NewQuizData
+
+	prompt := `
+You are an expert quiz generator. Your task is to create %d unique and high-quality quiz questions
+for the sub-category: "%s".
+
+Avoid generating questions that are too similar to existing themes covered by these keywords: [%s].
+
+For each question, provide the following information in JSON format:
+1.  "question": The quiz question text.
+2.  "model_answer": A concise and accurate model answer.
+3.  "keywords": An array of 2-5 relevant keywords for this question.
+4.  "difficulty": A string indicating the difficulty ("easy", "medium", or "hard").
+
+Ensure your entire response is a single JSON array containing %d JSON objects, each representing a quiz.
+Example for one quiz object:
+{
+  "question": "What is the capital of France?",
+  "model_answer": "Paris",
+  "keywords": ["france", "capital", "paris"],
+  "difficulty": "easy"
+}
+`
+	formattedPrompt := fmt.Sprintf(prompt, numQuestions, subCategoryName, strings.Join(existingKeywords, ", "), numQuestions)
+
+	a.logger.Info("Simulating LLM call with prompt:", zap.String("prompt", formattedPrompt))
+
+	// Simulate LLM response (hardcoded JSON string)
+	// In a real scenario, this would be:
+	// response, err := a.langchainClient.Invoke(ctx, formattedPrompt) // Or similar LangchainGo call
+	// if err != nil { return nil, err }
+	// then parse 'response'
+
+	// Create a distinct set of simulated responses based on numQuestions
+	simulatedResponses := []string{}
+	for i := 0; i < numQuestions; i++ {
+		simulatedResponses = append(simulatedResponses, fmt.Sprintf(`
+		{
+			"question": "Simulated Question %d for %s: What is the primary function of a CPU?",
+			"model_answer": "The primary function of a CPU is to execute instructions from computer programs.",
+			"keywords": ["cpu", "processor", "computer architecture", "question%d"],
+			"difficulty": "%s"
+		}`, i+1, subCategoryName, i+1, []string{"easy", "medium", "hard"}[i%3]))
+	}
+
+	simulatedJsonResponse := fmt.Sprintf("[%s]", strings.Join(simulatedResponses, ","))
+	a.logger.Info("Simulated LLM JSON response:", zap.String("json_response", simulatedJsonResponse))
+
+
+	var quizzesData []*domain.NewQuizData
+	// The LLM is expected to return a JSON array of quiz objects
+	err := json.Unmarshal([]byte(simulatedJsonResponse), &quizzesData)
+	if err != nil {
+		a.logger.Error("Failed to unmarshal simulated LLM JSON response", zap.Error(err), zap.String("json_response", simulatedJsonResponse))
+		return nil, fmt.Errorf("failed to parse LLM response: %w. Response: %s", err, simulatedJsonResponse)
+	}
+
+	if len(quizzesData) == 0 && numQuestions > 0 {
+	    a.logger.Warn("LLM simulation returned empty list but questions were requested", zap.Int("num_requested", numQuestions))
+        // Potentially return an error or handle as per requirements for zero items from LLM
+	}
+
+
+	for _, qd := range quizzesData {
+		// Basic validation (can be expanded)
+		if qd.Question == "" || qd.ModelAnswer == "" || len(qd.Keywords) == 0 || qd.Difficulty == "" {
+			a.logger.Warn("Simulated LLM generated incomplete quiz data", zap.Any("quiz_data", qd))
+			// Skip adding this incomplete data or return an error
+			continue
+		}
+		generatedQuizzes = append(generatedQuizzes, qd)
+	}
+
+	a.logger.Info("Successfully parsed simulated LLM response", zap.Int("num_quizzes_generated", len(generatedQuizzes)))
+	return generatedQuizzes, nil
+}
+
+// Static assertion to ensure GeminiQuizGenerator implements QuizGenerationService
+var _ domain.QuizGenerationService = (*GeminiQuizGenerator)(nil)

--- a/internal/adapter/quizgen/gemini_quiz_generator_test.go
+++ b/internal/adapter/quizgen/gemini_quiz_generator_test.go
@@ -1,0 +1,161 @@
+package quizgen_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/surna/quiz_app/internal/adapter/quizgen" // Use the actual package name
+	"github.com/surna/quiz_app/internal/domain"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+func TestNewGeminiQuizGenerator(t *testing.T) {
+	logger := zap.NewNop()
+	apiKey := "test-api-key"
+	modelName := "test-model"
+
+	svc, err := quizgen.NewGeminiQuizGenerator(apiKey, modelName, logger)
+	assert.NoError(t, err)
+	assert.NotNil(t, svc)
+
+	// Test with empty API key
+	_, err = quizgen.NewGeminiQuizGenerator("", modelName, logger)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "API key cannot be empty")
+
+	// Test with empty model name
+	_, err = quizgen.NewGeminiQuizGenerator(apiKey, "", logger)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "model name cannot be empty")
+}
+
+func TestGeminiQuizGenerator_GenerateQuizCandidates_Success(t *testing.T) {
+	logger := zap.NewNop()
+	apiKey := "test-api-key"
+	modelName := "test-model"
+
+	svc, err := quizgen.NewGeminiQuizGenerator(apiKey, modelName, logger)
+	require.NoError(t, err)
+	require.NotNil(t, svc)
+
+	ctx := context.Background()
+	subCategoryName := "Test SubCategory"
+	existingKeywords := []string{"keyword1", "keyword2"}
+	numQuestions := 2
+
+	quizDataSlice, err := svc.GenerateQuizCandidates(ctx, subCategoryName, existingKeywords, numQuestions)
+
+	assert.NoError(t, err)
+	require.NotNil(t, quizDataSlice)
+	require.Len(t, quizDataSlice, numQuestions, "Should return the number of questions requested")
+
+	// Assertions based on the hardcoded JSON structure in the adapter
+	for i, quizData := range quizDataSlice {
+		assert.NotEmpty(t, quizData.Question, "Question should not be empty for quiz %d", i+1)
+		// Example check based on the current hardcoded format
+		expectedQuestionSubstring := fmt.Sprintf("Simulated Question %d for %s", i+1, subCategoryName)
+		assert.Contains(t, quizData.Question, expectedQuestionSubstring, "Question content mismatch for quiz %d", i+1)
+
+		assert.NotEmpty(t, quizData.ModelAnswer, "ModelAnswer should not be empty for quiz %d", i+1)
+		assert.Contains(t, quizData.ModelAnswer, "primary function of a CPU", "ModelAnswer content mismatch for quiz %d", i+1)
+
+
+		require.NotEmpty(t, quizData.Keywords, "Keywords should not be empty for quiz %d", i+1)
+		assert.Contains(t, quizData.Keywords, "cpu", "Keywords mismatch for quiz %d", i+1)
+		assert.Contains(t, quizData.Keywords, fmt.Sprintf("question%d", i+1), "Keywords mismatch for quiz %d", i+1)
+
+
+		assert.NotEmpty(t, quizData.Difficulty, "Difficulty should not be empty for quiz %d", i+1)
+		expectedDifficulty := []string{"easy", "medium", "hard"}[i%3]
+		assert.Equal(t, expectedDifficulty, quizData.Difficulty, "Difficulty mismatch for quiz %d", i+1)
+	}
+}
+
+// TestGenerateQuizCandidates_MalformedJSON (Conceptual as per subtask description)
+// To truly test this, the JSON generation/fetching part in the SUT would need to be mockable
+// or the internal hardcoded string would need to be made malformed for this specific test.
+// The current implementation of GeminiQuizGenerator always produces valid JSON string.
+// If the hardcoded string in GeminiQuizGenerator were to become malformed,
+// the json.Unmarshal call would return an error, which is covered by standard error handling.
+// This test case serves as a placeholder for how one might approach it if the SUT were different.
+func TestGeminiQuizGenerator_GenerateQuizCandidates_MalformedJSON_Conceptual(t *testing.T) {
+	t.Skip("Skipping MalformedJSON test as it requires SUT modification or specific mocking for current structure")
+	// If we could inject the JSON response or if the SUT fetched it from an external source:
+	// 1. Setup the service.
+	// 2. Mock the LLM call to return a malformed JSON string.
+	//    e.g., `mockLLM.On("Call", mock.Anything).Return("this is not json", nil)`
+	// 3. Call GenerateQuizCandidates.
+	// 4. Assert that an error is returned and it's related to JSON parsing.
+	//    `assert.Error(t, err)`
+	//    `assert.Contains(t, err.Error(), "failed to parse LLM response")`
+}
+
+
+// TestGenerateQuizCandidates_PromptConstruction (Conceptual - requires logger capture)
+// The current GeminiQuizGenerator logs the prompt. To test this, we'd need a logger
+// that writes to a buffer.
+func TestGeminiQuizGenerator_GenerateQuizCandidates_PromptConstruction_Conceptual(t *testing.T) {
+	t.Skip("Skipping PromptConstruction test as it requires logger capture setup")
+
+	// Example of how it could be done with a logger that supports capturing output:
+	// var logBuffer bytes.Buffer
+	// logger := zap.New(zapcore.NewCore(
+	//     zapcore.NewConsoleEncoder(zap.NewDevelopmentEncoderConfig()),
+	//     zapcore.AddSync(&logBuffer),
+	//     zap.InfoLevel,
+	// ))
+	//
+	// apiKey := "test-api-key"
+	// modelName := "test-model"
+	// svc, _ := quizgen.NewGeminiQuizGenerator(apiKey, modelName, logger)
+	//
+	// ctx := context.Background()
+	// subCategoryName := "Test Prompt Construction"
+	// existingKeywords := []string{"prompt_keyword1", "pk2"}
+	// numQuestions := 1
+	//
+	// _, _ = svc.GenerateQuizCandidates(ctx, subCategoryName, existingKeywords, numQuestions)
+	//
+	// loggedOutput := logBuffer.String()
+	// assert.Contains(t, loggedOutput, subCategoryName)
+	// assert.Contains(t, loggedOutput, "prompt_keyword1")
+	// assert.Contains(t, loggedOutput, "pk2")
+	// assert.Contains(t, loggedOutput, fmt.Sprintf("create %d unique", numQuestions))
+	// assert.Contains(t, loggedOutput, "JSON format")
+	// assert.Contains(t, loggedOutput, "\"question\"")
+	// assert.Contains(t, loggedOutput, "\"model_answer\"")
+	// assert.Contains(t, loggedOutput, "\"keywords\"")
+	// assert.Contains(t, loggedOutput, "\"difficulty\"")
+}
+
+// It's also useful to test how the service handles an empty or nil response from the LLM
+// (if the LLM could theoretically return that for a valid request).
+// The current simulation always returns data if numQuestions > 0.
+func TestGeminiQuizGenerator_GenerateQuizCandidates_EmptyResponseFromLLM(t *testing.T) {
+    logger := zap.NewNop()
+    apiKey := "test-api-key"
+    modelName := "test-model"
+
+    svc, err := quizgen.NewGeminiQuizGenerator(apiKey, modelName, logger)
+    require.NoError(t, err)
+    require.NotNil(t, svc)
+
+    ctx := context.Background()
+    subCategoryName := "Test Empty Response"
+    existingKeywords := []string{}
+    numQuestions := 0 // Requesting zero questions
+
+    quizDataSlice, err := svc.GenerateQuizCandidates(ctx, subCategoryName, existingKeywords, numQuestions)
+
+    assert.NoError(t, err)
+    require.NotNil(t, quizDataSlice) // Should return an empty slice, not nil
+    assert.Len(t, quizDataSlice, 0, "Should return an empty slice when 0 questions are requested")
+
+	// The adapter's current simulation will produce an empty JSON array "[]" if numQuestions is 0.
+	// This will be parsed correctly into an empty slice.
+}

--- a/internal/domain/batch.go
+++ b/internal/domain/batch.go
@@ -1,0 +1,16 @@
+package domain
+
+import "context"
+
+// NewQuizData represents the data expected from the LLM.
+type NewQuizData struct {
+	Question    string
+	ModelAnswer string
+	Keywords    []string
+	Difficulty  string
+}
+
+// BatchService defines the interface for batch operations.
+type BatchService interface {
+	GenerateNewQuizzesAndSave(ctx context.Context) error
+}

--- a/internal/domain/quizgen.go
+++ b/internal/domain/quizgen.go
@@ -1,0 +1,19 @@
+package domain
+
+import (
+	"context"
+	// NewQuizData is defined in internal/domain/batch.go, which is also package domain.
+	// Therefore, it's directly accessible here.
+)
+
+// QuizGenerationService defines the interface for generating quiz candidates.
+type QuizGenerationService interface {
+	// GenerateQuizCandidates generates a specified number of quiz candidates
+	// for a given subcategory, considering existing keywords to promote novelty.
+	GenerateQuizCandidates(
+		ctx context.Context,
+		subCategoryName string,
+		existingKeywords []string,
+		numQuestions int,
+	) ([]*NewQuizData, error)
+}

--- a/internal/domain/service.go
+++ b/internal/domain/service.go
@@ -26,10 +26,12 @@ type QuizRepository interface {
 	GetRandomQuiz() (*Quiz, error)
 	GetRandomQuizBySubCategory(subCategory string) (*Quiz, error)
 	GetSimilarQuiz(quizID string) (*Quiz, error)
-	GetAllSubCategories() ([]string, error)
-	SaveAnswer(answer *Answer) error
+	GetAllSubCategories(ctx context.Context) ([]string, error)
+	SaveAnswer(answer *Answer) error // Assuming SaveAnswer might also need context later, but not in scope for this change
+	SaveQuiz(ctx context.Context, quiz *Quiz) error
 	GetQuizzesByCriteria(SubCategoryID string, limit int) ([]*Quiz, error)
 	GetSubCategoryIDByName(name string) (string, error)
+	GetQuizzesBySubCategory(ctx context.Context, subCategoryID string) ([]*Quiz, error)
 }
 
 // CategoryRepository defines the interface for category persistence

--- a/internal/service/batch_service.go
+++ b/internal/service/batch_service.go
@@ -1,0 +1,236 @@
+package service
+
+import (
+	"context"
+	"fmt" // Keep for basic logging/placeholder, zap will be main
+	"time" // For logging timestamps if not implicitly handled by zap
+
+	"github.com/surna/quiz_app/internal/config"
+	"github.com/surna/quiz_app/internal/domain"
+	"github.com/surna/quiz_app/internal/util" // For CosineSimilarity and NewULID
+	"go.uber.org/zap"
+)
+
+// batchService implements the domain.BatchService interface.
+type batchService struct {
+	quizRepo         domain.QuizRepository
+	categoryRepo     domain.CategoryRepository
+	embeddingService domain.EmbeddingService
+	quizGenSvc       domain.QuizGenerationService // Renamed from llmClient
+	cfg              *config.Config
+	logger           *zap.Logger
+}
+
+// NewBatchService creates a new instance of batchService.
+func NewBatchService(
+	quizRepo domain.QuizRepository,
+	categoryRepo domain.CategoryRepository,
+	embeddingService domain.EmbeddingService,
+	quizGenSvc domain.QuizGenerationService, // Renamed from llmClient
+	cfg *config.Config,
+	logger *zap.Logger,
+) domain.BatchService {
+	return &batchService{
+		quizRepo:         quizRepo,
+		categoryRepo:     categoryRepo,
+		embeddingService: embeddingService,
+		quizGenSvc:       quizGenSvc, // Renamed from llmClient
+		cfg:              cfg,
+		logger:           logger,
+	}
+}
+
+// GenerateNewQuizzesAndSave implements the logic to generate and save new quizzes.
+func (s *batchService) GenerateNewQuizzesAndSave(ctx context.Context) error {
+	s.logger.Info("Starting batch quiz generation process", zap.Time("start_time", time.Now()))
+
+	existingEmbeddingsCache := make(map[string][]float32)
+
+	subCategoryIDs, err := s.quizRepo.GetAllSubCategories(ctx)
+	if err != nil {
+		s.logger.Error("Failed to fetch subcategory IDs", zap.Error(err))
+		return fmt.Errorf("failed to fetch subcategory IDs: %w", err)
+	}
+
+	if len(subCategoryIDs) == 0 {
+		s.logger.Info("No subcategories found. Batch process finishing early.")
+		return nil
+	}
+
+	for _, subCategoryID := range subCategoryIDs {
+		existingEmbeddingsCache = make(map[string][]float32) // Reset for each subcategory
+		s.logger.Info("Processing subcategory", zap.String("subcategory_id", subCategoryID))
+
+		existingQuizzes, err := s.quizRepo.GetQuizzesBySubCategory(ctx, subCategoryID)
+		if err != nil {
+			s.logger.Error("Failed to fetch existing quizzes for subcategory",
+				zap.String("subcategory_id", subCategoryID),
+				zap.Error(err),
+			)
+			// Continue to the next subcategory, or return error? For now, continue.
+			continue
+		}
+		s.logger.Info("Fetched existing quizzes for subcategory",
+			zap.String("subcategory_id", subCategoryID),
+			zap.Int("count", len(existingQuizzes)),
+		)
+
+		// Build a list of existing question texts (placeholder for now)
+		// This list could be passed to the LLM to avoid generating similar questions.
+		// var existingQuestionTexts []string
+		// for _, q := range existingQuizzes {
+		// 	existingQuestionTexts = append(existingQuestionTexts, q.Question)
+		// }
+		// s.logger.Debug("Existing questions in subcategory", zap.Strings("questions", existingQuestionTexts))
+
+		// TODO: Fetch SubCategoryName based on subCategoryID if needed by LLMClient, or pass ID directly
+		// For now, we'll pass subCategoryID as subCategoryName, assuming LLM can work with it or it's just for context.
+		subCategoryNameForLLM := subCategoryID // Placeholder, might need actual name
+
+		// Collect existing keywords from the questions in the current subcategory
+		var existingKeywordsForLLM []string
+		for _, q := range existingQuizzes {
+			existingKeywordsForLLM = append(existingKeywordsForLLM, q.Keywords...)
+		}
+		// Deduplicate keywords if necessary, though for the prompt, some repetition might be okay.
+
+		numQuestionsToGenerate := s.cfg.Batch.NumQuestionsPerSubCategory // Assuming this config exists
+		if numQuestionsToGenerate == 0 {
+			numQuestionsToGenerate = 2 // Default if not configured
+		}
+
+		generatedQuizzesData, err := s.quizGenSvc.GenerateQuizCandidates(ctx, subCategoryNameForLLM, existingKeywordsForLLM, numQuestionsToGenerate)
+		if err != nil {
+			s.logger.Error("Failed to generate quiz candidates from QuizGenerationService", // Updated log message
+				zap.String("subcategory_id", subCategoryID),
+				zap.Error(err),
+			)
+			continue // Skip to the next subcategory
+		}
+
+		if len(generatedQuizzesData) == 0 {
+			s.logger.Info("LLM returned no quiz data for subcategory", zap.String("subcategory_id", subCategoryID))
+			continue
+		}
+
+		s.logger.Info("Successfully received quiz candidates from QuizGenerationService", // Updated log message
+			zap.String("subcategory_id", subCategoryID),
+			zap.Int("num_generated", len(generatedQuizzesData)),
+		)
+
+		for _, generatedQuiz := range generatedQuizzesData { // Iterate over pointer to NewQuizData
+			if generatedQuiz == nil {
+				s.logger.Warn("LLM returned a nil quiz data object, skipping", zap.String("subcategory_id", subCategoryID))
+				continue
+			}
+			s.logger.Info("Processing generated quiz data", zap.String("question", generatedQuiz.Question))
+
+			newQuizEmbedding, err := s.embeddingService.Generate(ctx, generatedQuiz.Question)
+			if err != nil {
+				s.logger.Error("Failed to generate embedding for new quiz",
+					zap.String("question", generatedQuiz.Question), // Corrected generatedQuizData to generatedQuiz
+					zap.Error(err),
+				)
+				continue // Skip this generated quiz
+			}
+
+			isUnique := true
+			for _, existingQuiz := range existingQuizzes {
+				var existingQuizEmbedding []float32
+				var errEmbedding error
+
+				if emb, found := existingEmbeddingsCache[existingQuiz.ID]; found {
+					existingQuizEmbedding = emb
+				} else {
+					existingQuizEmbedding, errEmbedding = s.embeddingService.Generate(ctx, existingQuiz.Question)
+					if errEmbedding != nil {
+						s.logger.Error("Failed to generate embedding for existing quiz",
+							zap.String("quiz_id", existingQuiz.ID),
+							zap.String("question", existingQuiz.Question),
+							zap.Error(errEmbedding),
+						)
+						// If we can't generate embedding for an existing quiz, we can't compare.
+						// Depending on policy, we might skip comparison or assume it's not similar.
+						// For now, log and continue (meaning it won't be flagged as non-unique due to this error).
+						continue
+					}
+					existingEmbeddingsCache[existingQuiz.ID] = existingQuizEmbedding
+				}
+
+				if len(newQuizEmbedding) == 0 || len(existingQuizEmbedding) == 0 {
+				    s.logger.Warn("One or both embeddings are empty, skipping similarity check.",
+				        zap.String("new_quiz_question", generatedQuiz.Question), // Corrected field
+				        zap.String("existing_quiz_id", existingQuiz.ID),
+				    )
+				    continue
+				}
+
+
+				similarity, err := util.CosineSimilarity(newQuizEmbedding, existingQuizEmbedding)
+				if err != nil {
+					s.logger.Error("Failed to calculate cosine similarity",
+						zap.String("new_quiz_question", generatedQuiz.Question), // Corrected field
+						zap.String("existing_quiz_id", existingQuiz.ID),
+						zap.Error(err),
+					)
+					// If similarity calculation fails, policy decision:
+					// Treat as not similar and proceed, or skip? For now, treat as not similar.
+					continue
+				}
+
+				s.logger.Debug("Calculated similarity",
+					zap.String("new_quiz_question", generatedQuiz.Question), // Corrected field
+					zap.String("existing_quiz_id", existingQuiz.ID),
+					zap.Float64("similarity", similarity),
+					zap.Float64("threshold", s.cfg.Embedding.SimilarityThreshold),
+				)
+
+				if similarity >= s.cfg.Embedding.SimilarityThreshold {
+					isUnique = false
+					s.logger.Info("Generated quiz is too similar to existing quiz",
+						zap.String("generated_question", generatedQuiz.Question), // Corrected field
+						zap.String("existing_quiz_id", existingQuiz.ID),
+						zap.String("existing_quiz_question", existingQuiz.Question),
+						zap.Float64("similarity", similarity),
+					)
+					break // Found a similar existing quiz, no need to check others
+				}
+			}
+
+			if isUnique {
+				newDomainQuiz := domain.Quiz{
+					// ID will be set by SaveQuiz or here, let's ensure it's set before save
+					ID:            util.NewULID(),
+					Question:      generatedQuiz.Question,
+					ModelAnswers:  []string{generatedQuiz.ModelAnswer},
+					Keywords:      generatedQuiz.Keywords,
+					Difficulty:    domain.DifficultyToInt(generatedQuiz.Difficulty),
+					SubCategoryID: subCategoryID,
+					// CreatedAt and UpdatedAt will be set by the repository
+				}
+
+				err = s.quizRepo.SaveQuiz(ctx, &newDomainQuiz) // Pass context
+				if err != nil {
+					s.logger.Error("Failed to save new unique quiz",
+						zap.String("question", newDomainQuiz.Question),
+						zap.Error(err),
+					)
+					// Continue to next generated quiz even if one save fails
+				} else {
+					s.logger.Info("Successfully saved new unique quiz",
+						zap.String("quiz_id", newDomainQuiz.ID),
+						zap.String("question", newDomainQuiz.Question),
+					)
+				}
+			} else {
+				s.logger.Info("Skipped saving quiz due to similarity",
+					zap.String("question", generatedQuiz.Question), // Corrected field
+				)
+			}
+		} // End loop for generatedQuizzesData
+		s.logger.Info("Finished processing subcategory", zap.String("subcategory_id", subCategoryID))
+	}
+
+	s.logger.Info("Batch quiz generation process completed", zap.Time("end_time", time.Now()))
+	return nil
+}

--- a/internal/service/batch_service_test.go
+++ b/internal/service/batch_service_test.go
@@ -1,0 +1,521 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/surna/quiz_app/internal/config"
+	"github.com/surna/quiz_app/internal/domain"
+	"github.com/surna/quiz_app/internal/util" // For actual CosineSimilarity
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"go.uber.org/zap"
+)
+
+// --- Mock QuizRepository ---
+type MockQuizRepository struct {
+	mock.Mock
+}
+
+func (m *MockQuizRepository) GetAllSubCategories(ctx context.Context) ([]string, error) {
+	args := m.Called(ctx)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]string), args.Error(1)
+}
+
+func (m *MockQuizRepository) GetQuizzesBySubCategory(ctx context.Context, subCategoryID string) ([]*domain.Quiz, error) {
+	args := m.Called(ctx, subCategoryID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]*domain.Quiz), args.Error(1)
+}
+
+func (m *MockQuizRepository) SaveQuiz(ctx context.Context, quiz *domain.Quiz) error {
+	args := m.Called(ctx, quiz)
+	return args.Error(0)
+}
+
+// Add other QuizRepository methods if they become used by the service in the future
+// For now, these are the ones directly used by GenerateNewQuizzesAndSave:
+// GetQuizByID(id string) (*Quiz, error)
+// GetRandomQuiz() (*Quiz, error)
+// GetRandomQuizBySubCategory(subCategory string) (*Quiz, error)
+// GetSimilarQuiz(quizID string) (*Quiz, error)
+// SaveAnswer(answer *Answer) error
+// GetQuizzesByCriteria(SubCategoryID string, limit int) ([]*Quiz, error)
+// GetSubCategoryIDByName(name string) (string, error)
+func (m *MockQuizRepository) GetQuizByID(id string) (*domain.Quiz, error) {
+	args := m.Called(id)
+	return args.Get(0).(*domain.Quiz), args.Error(1)
+}
+func (m *MockQuizRepository) GetRandomQuiz() (*domain.Quiz, error) {
+	args := m.Called()
+	return args.Get(0).(*domain.Quiz), args.Error(1)
+}
+func (m *MockQuizRepository) GetRandomQuizBySubCategory(subCategory string) (*domain.Quiz, error) {
+	args := m.Called(subCategory)
+	return args.Get(0).(*domain.Quiz), args.Error(1)
+}
+func (m *MockQuizRepository) GetSimilarQuiz(quizID string) (*domain.Quiz, error) {
+	args := m.Called(quizID)
+	return args.Get(0).(*domain.Quiz), args.Error(1)
+}
+func (m *MockQuizRepository) SaveAnswer(answer *domain.Answer) error {
+	args := m.Called(answer)
+	return args.Error(0)
+}
+func (m *MockQuizRepository) GetQuizzesByCriteria(SubCategoryID string, limit int) ([]*domain.Quiz, error) {
+	args := m.Called(SubCategoryID, limit)
+	return args.Get(0).([]*domain.Quiz), args.Error(1)
+}
+func (m *MockQuizRepository) GetSubCategoryIDByName(name string) (string, error) {
+	args := m.Called(name)
+	return args.String(0), args.Error(1)
+}
+
+
+// --- Mock CategoryRepository ---
+type MockCategoryRepository struct {
+	mock.Mock
+}
+// Implement methods from domain.CategoryRepository if used by batchService.
+// For GenerateNewQuizzesAndSave, it's not directly used, so methods can be minimal or omitted for now.
+func (m *MockCategoryRepository) GetAllCategories() ([]*domain.Category, error) {
+    args := m.Called()
+    if args.Get(0) == nil {
+        return nil, args.Error(1)
+    }
+    return args.Get(0).([]*domain.Category), args.Error(1)
+}
+func (m *MockCategoryRepository) GetSubCategories(categoryID string) ([]*domain.SubCategory, error) {
+    args := m.Called(categoryID)
+     if args.Get(0) == nil {
+        return nil, args.Error(1)
+    }
+    return args.Get(0).([]*domain.SubCategory), args.Error(1)
+}
+func (m *MockCategoryRepository) SaveCategory(category *domain.Category) error {
+    args := m.Called(category)
+    return args.Error(0)
+}
+func (m *MockCategoryRepository) SaveSubCategory(subCategory *domain.SubCategory) error {
+    args := m.Called(subCategory)
+    return args.Error(0)
+}
+
+
+// --- Mock EmbeddingService ---
+type MockEmbeddingService struct {
+	mock.Mock
+}
+
+func (m *MockEmbeddingService) Generate(ctx context.Context, text string) ([]float32, error) {
+	args := m.Called(ctx, text)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]float32), args.Error(1)
+}
+
+// --- Mock QuizGenerationService ---
+type MockQuizGenerationService struct {
+	mock.Mock
+}
+
+func (m *MockQuizGenerationService) GenerateQuizCandidates(
+	ctx context.Context,
+	subCategoryName string,
+	existingKeywords []string,
+	numQuestions int,
+) ([]*domain.NewQuizData, error) {
+	args := m.Called(ctx, subCategoryName, existingKeywords, numQuestions)
+	if args.Get(0) == nil { // Handle nil case for slice if error is returned
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]*domain.NewQuizData), args.Error(1)
+}
+
+
+// --- Test Suite ---
+func TestGenerateNewQuizzesAndSave_Success_NewUniqueQuizzes(t *testing.T) {
+	mockQuizRepo := new(MockQuizRepository)
+	mockCategoryRepo := new(MockCategoryRepository) // Not used in current GenerateNewQuizzesAndSave
+	mockEmbeddingService := new(MockEmbeddingService)
+	mockQuizGenSvc := new(MockQuizGenerationService) // Renamed from mockLLMClient
+
+	logger, _ := zap.NewDevelopment()
+	cfg := &config.Config{
+		Embedding: config.EmbeddingConfig{SimilarityThreshold: 0.9},
+		Batch:     config.BatchConfig{NumQuestionsPerSubCategory: 1},
+	}
+
+	batchSvc := NewBatchService(mockQuizRepo, mockCategoryRepo, mockEmbeddingService, mockQuizGenSvc, cfg, logger) // Updated argument
+
+	ctx := context.Background()
+	subCategoryID1 := "subCat1"
+
+	// Mock expectations
+	mockQuizRepo.On("GetAllSubCategories", ctx).Return([]string{subCategoryID1}, nil).Once()
+	mockQuizRepo.On("GetQuizzesBySubCategory", ctx, subCategoryID1).Return([]*domain.Quiz{}, nil).Once() // No existing quizzes
+
+	generatedQuiz1 := &domain.NewQuizData{
+		Question:    "New Q1?",
+		ModelAnswer: "Ans1",
+		Keywords:    []string{"k1", "k2"},
+		Difficulty:  "easy",
+	}
+	mockQuizGenSvc.On("GenerateQuizCandidates", ctx, subCategoryID1, []string{}, 1).Return([]*domain.NewQuizData{generatedQuiz1}, nil).Once() // Updated mock call
+
+	embeddingForGeneratedQ1 := []float32{0.1, 0.2, 0.3}
+	mockEmbeddingService.On("Generate", ctx, generatedQuiz1.Question).Return(embeddingForGeneratedQ1, nil).Once()
+
+	// Expect SaveQuiz to be called because it's unique (no existing quizzes)
+	mockQuizRepo.On("SaveQuiz", ctx, mock.MatchedBy(func(quiz *domain.Quiz) bool {
+		return quiz.Question == generatedQuiz1.Question && quiz.SubCategoryID == subCategoryID1
+	})).Return(nil).Once()
+
+	// Execute
+	err := batchSvc.GenerateNewQuizzesAndSave(ctx)
+
+	// Assertions
+	assert.NoError(t, err)
+	mockQuizRepo.AssertExpectations(t)
+	mockQuizGenSvc.AssertExpectations(t) // Updated mock
+	mockEmbeddingService.AssertExpectations(t)
+	mockQuizRepo.AssertCalled(t, "SaveQuiz", ctx, mock.AnythingOfType("*domain.Quiz"))
+}
+
+func TestGenerateNewQuizzesAndSave_Success_SomeSimilarQuizzes(t *testing.T) {
+	mockQuizRepo := new(MockQuizRepository)
+	mockCategoryRepo := new(MockCategoryRepository)
+	mockEmbeddingService := new(MockEmbeddingService)
+	mockQuizGenSvc := new(MockQuizGenerationService) // Renamed from mockLLMClient
+
+	logger, _ := zap.NewDevelopment()
+	cfg := &config.Config{
+		Embedding: config.EmbeddingConfig{SimilarityThreshold: 0.95}, // Higher threshold
+		Batch:     config.BatchConfig{NumQuestionsPerSubCategory: 2},     // Generate 2 questions
+	}
+
+	batchSvc := NewBatchService(mockQuizRepo, mockCategoryRepo, mockEmbeddingService, mockQuizGenSvc, cfg, logger) // Updated argument
+	ctx := context.Background()
+	subCategoryID1 := "subCatSimilar"
+
+	existingQuiz1 := &domain.Quiz{
+		ID:            "existing1",
+		Question:      "Existing Question 1",
+		ModelAnswers:  []string{"Existing Answer 1"},
+		Keywords:      []string{"exist", "q1"},
+		Difficulty:    1,
+		SubCategoryID: subCategoryID1,
+	}
+	mockQuizRepo.On("GetAllSubCategories", ctx).Return([]string{subCategoryID1}, nil).Once()
+	mockQuizRepo.On("GetQuizzesBySubCategory", ctx, subCategoryID1).Return([]*domain.Quiz{existingQuiz1}, nil).Once()
+
+	// LLM generates two quizzes
+	generatedQuizUnique := &domain.NewQuizData{
+		Question:    "Totally New Unique Question",
+		ModelAnswer: "Unique Ans",
+		Keywords:    []string{"unique", "new"},
+		Difficulty:  "medium",
+	}
+	generatedQuizSimilar := &domain.NewQuizData{ // This one will be similar to existingQuiz1
+		Question:    "Very Similar Existing Question 1",
+		ModelAnswer: "Similar Ans",
+		Keywords:    []string{"exist", "q1", "similar"},
+		Difficulty:  "easy",
+	}
+	mockQuizGenSvc.On("GenerateQuizCandidates", ctx, subCategoryID1, mock.AnythingOfType("[]string"), 2).Return([]*domain.NewQuizData{generatedQuizUnique, generatedQuizSimilar}, nil).Once() // Updated mock call
+
+	// Embeddings
+	embeddingExistingQ1 := []float32{0.1, 0.2, 0.3, 0.4, 0.5}
+	embeddingGeneratedUnique := []float32{0.5, 0.4, 0.3, 0.2, 0.1} // Different
+	embeddingGeneratedSimilar := []float32{0.1, 0.2, 0.3, 0.4, 0.5} // Same as existingQ1 for test
+
+	// Order of Generate calls can be tricky if not strictly sequential in code.
+	// For existing quiz (might be cached or generated)
+	mockEmbeddingService.On("Generate", ctx, existingQuiz1.Question).Return(embeddingExistingQ1, nil).Maybe() // Maybe, because it could be cached
+
+	// For generated unique quiz
+	mockEmbeddingService.On("Generate", ctx, generatedQuizUnique.Question).Return(embeddingGeneratedUnique, nil).Once()
+	// For generated similar quiz
+	mockEmbeddingService.On("Generate", ctx, generatedQuizSimilar.Question).Return(embeddingGeneratedSimilar, nil).Once()
+
+	// CosineSimilarity will be called. We are using the real util.CosineSimilarity.
+	// If we were mocking it:
+	// mockUtil.On("CosineSimilarity", embeddingGeneratedUnique, embeddingExistingQ1).Return(0.5, nil) // Low similarity
+	// mockUtil.On("CosineSimilarity", embeddingGeneratedSimilar, embeddingExistingQ1).Return(0.98, nil) // High similarity
+
+	// Expect SaveQuiz to be called only for the unique one
+	mockQuizRepo.On("SaveQuiz", ctx, mock.MatchedBy(func(quiz *domain.Quiz) bool {
+		return quiz.Question == generatedQuizUnique.Question
+	})).Return(nil).Once()
+
+
+	err := batchSvc.GenerateNewQuizzesAndSave(ctx)
+	assert.NoError(t, err)
+
+	mockQuizRepo.AssertExpectations(t)
+	mockQuizGenSvc.AssertExpectations(t) // Updated mock
+	mockEmbeddingService.AssertExpectations(t)
+
+	// Assert SaveQuiz was called once (for the unique quiz)
+	mockQuizRepo.AssertNumberOfCalls(t, "SaveQuiz", 1)
+}
+
+func TestGenerateNewQuizzesAndSave_Error_GetAllSubCategoriesFails(t *testing.T) {
+	mockQuizRepo := new(MockQuizRepository)
+	// ... other mocks are not strictly necessary for this specific error path but good practice
+	mockCategoryRepo := new(MockCategoryRepository)
+	mockEmbeddingService := new(MockEmbeddingService)
+	mockQuizGenSvc := new(MockQuizGenerationService) // Renamed from mockLLMClient
+
+	logger, _ := zap.NewDevelopment()
+	cfg := &config.Config{} // Config might not be deeply accessed if it fails early
+
+	batchSvc := NewBatchService(mockQuizRepo, mockCategoryRepo, mockEmbeddingService, mockQuizGenSvc, cfg, logger) // Updated argument
+	ctx := context.Background()
+
+	expectedError := errors.New("db error on GetAllSubCategories")
+	mockQuizRepo.On("GetAllSubCategories", ctx).Return(nil, expectedError).Once()
+
+	err := batchSvc.GenerateNewQuizzesAndSave(ctx)
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), expectedError.Error())
+	mockQuizRepo.AssertExpectations(t)
+	// Ensure other downstream calls were not made
+	mockQuizGenSvc.AssertNotCalled(t, "GenerateQuizCandidates", mock.Anything, mock.Anything, mock.Anything, mock.Anything) // Updated mock
+	mockQuizRepo.AssertNotCalled(t, "SaveQuiz", mock.Anything, mock.Anything)
+}
+
+func TestGenerateNewQuizzesAndSave_Error_GetQuizzesBySubCategoryFails(t *testing.T) {
+    mockQuizRepo := new(MockQuizRepository)
+    mockCategoryRepo := new(MockCategoryRepository)
+    mockEmbeddingService := new(MockEmbeddingService)
+    mockQuizGenSvc := new(MockQuizGenerationService) // Renamed from mockLLMClient
+
+    logger, _ := zap.NewDevelopment()
+    cfg := &config.Config{
+        Embedding: config.EmbeddingConfig{SimilarityThreshold: 0.9},
+        Batch:     config.BatchConfig{NumQuestionsPerSubCategory: 1},
+    }
+    batchSvc := NewBatchService(mockQuizRepo, mockCategoryRepo, mockEmbeddingService, mockQuizGenSvc, cfg, logger) // Updated argument
+    ctx := context.Background()
+    subCategoryID1 := "subCatErr"
+    expectedError := errors.New("db error on GetQuizzesBySubCategory")
+
+    mockQuizRepo.On("GetAllSubCategories", ctx).Return([]string{subCategoryID1}, nil).Once()
+    mockQuizRepo.On("GetQuizzesBySubCategory", ctx, subCategoryID1).Return(nil, expectedError).Once()
+
+    // The service currently logs this error and continues to the next subcategory (if any).
+    // If it were the only subcategory, the overall function would still return nil.
+    // To test this specific error causing a non-nil return, the service logic would need to change,
+    // or this test needs to reflect that it might still be a `nil` error overall for the batch.
+    // For now, let's assume the batch continues, so overall error is nil.
+    err := batchSvc.GenerateNewQuizzesAndSave(ctx)
+    assert.NoError(t, err) // Because the service continues on this specific error
+
+    mockQuizRepo.AssertExpectations(t)
+    mockQuizGenSvc.AssertNotCalled(t, "GenerateQuizCandidates", mock.Anything, mock.Anything, mock.Anything, mock.Anything) // Updated mock
+}
+
+
+func TestGenerateNewQuizzesAndSave_Error_LLMClientFails(t *testing.T) { // Name will be updated to reflect QuizGenerationService
+    mockQuizRepo := new(MockQuizRepository)
+    mockCategoryRepo := new(MockCategoryRepository)
+    mockEmbeddingService := new(MockEmbeddingService)
+    mockQuizGenSvc := new(MockQuizGenerationService) // Renamed from mockLLMClient
+
+    logger, _ := zap.NewDevelopment()
+    cfg := &config.Config{
+        Embedding: config.EmbeddingConfig{SimilarityThreshold: 0.9},
+        Batch:     config.BatchConfig{NumQuestionsPerSubCategory: 1},
+    }
+    batchSvc := NewBatchService(mockQuizRepo, mockCategoryRepo, mockEmbeddingService, mockQuizGenSvc, cfg, logger) // Updated argument
+    ctx := context.Background()
+    subCategoryID1 := "subCatLLMErr"
+    expectedError := errors.New("LLM failed")
+
+    mockQuizRepo.On("GetAllSubCategories", ctx).Return([]string{subCategoryID1}, nil).Once()
+    mockQuizRepo.On("GetQuizzesBySubCategory", ctx, subCategoryID1).Return([]*domain.Quiz{}, nil).Once()
+    mockQuizGenSvc.On("GenerateQuizCandidates", ctx, subCategoryID1, []string{}, 1).Return(nil, expectedError).Once() // Updated mock call
+
+    // Service logs and continues
+    err := batchSvc.GenerateNewQuizzesAndSave(ctx)
+    assert.NoError(t, err) // Batch continues
+
+    mockQuizRepo.AssertExpectations(t)
+    mockQuizGenSvc.AssertExpectations(t) // Updated mock
+    mockEmbeddingService.AssertNotCalled(t, "Generate", mock.Anything, mock.Anything)
+    mockQuizRepo.AssertNotCalled(t, "SaveQuiz", mock.Anything, mock.Anything)
+}
+
+func TestGenerateNewQuizzesAndSave_Error_EmbeddingServiceFailsOnNewQuiz(t *testing.T) {
+    mockQuizRepo := new(MockQuizRepository)
+    mockCategoryRepo := new(MockCategoryRepository)
+    mockEmbeddingService := new(MockEmbeddingService)
+    mockQuizGenSvc := new(MockQuizGenerationService) // Renamed from mockLLMClient
+
+    logger, _ := zap.NewDevelopment()
+    cfg := &config.Config{
+        Embedding: config.EmbeddingConfig{SimilarityThreshold: 0.9},
+        Batch:     config.BatchConfig{NumQuestionsPerSubCategory: 1},
+    }
+    batchSvc := NewBatchService(mockQuizRepo, mockCategoryRepo, mockEmbeddingService, mockQuizGenSvc, cfg, logger) // Updated argument
+    ctx := context.Background()
+    subCategoryID1 := "subCatEmbedErr"
+
+    generatedQuiz1 := &domain.NewQuizData{Question: "Q Embed Err", ModelAnswer: "A", Keywords: []string{"k"}, Difficulty: "easy"}
+    expectedError := errors.New("embedding failed")
+
+    mockQuizRepo.On("GetAllSubCategories", ctx).Return([]string{subCategoryID1}, nil).Once()
+    mockQuizRepo.On("GetQuizzesBySubCategory", ctx, subCategoryID1).Return([]*domain.Quiz{}, nil).Once()
+    mockQuizGenSvc.On("GenerateQuizCandidates", ctx, subCategoryID1, []string{}, 1).Return([]*domain.NewQuizData{generatedQuiz1}, nil).Once() // Updated mock call
+    mockEmbeddingService.On("Generate", ctx, generatedQuiz1.Question).Return(nil, expectedError).Once()
+
+    // Service logs and continues
+    err := batchSvc.GenerateNewQuizzesAndSave(ctx)
+    assert.NoError(t, err) // Batch continues
+
+    mockQuizRepo.AssertExpectations(t)
+    mockQuizGenSvc.AssertExpectations(t) // Updated mock
+    mockEmbeddingService.AssertExpectations(t)
+    mockQuizRepo.AssertNotCalled(t, "SaveQuiz", mock.Anything, mock.Anything)
+}
+
+
+func TestGenerateNewQuizzesAndSave_Error_SaveQuizFails(t *testing.T) {
+    mockQuizRepo := new(MockQuizRepository)
+    mockCategoryRepo := new(MockCategoryRepository)
+    mockEmbeddingService := new(MockEmbeddingService)
+    mockQuizGenSvc := new(MockQuizGenerationService) // Renamed from mockLLMClient
+
+    logger, _ := zap.NewDevelopment()
+    cfg := &config.Config{
+        Embedding: config.EmbeddingConfig{SimilarityThreshold: 0.9},
+        Batch:     config.BatchConfig{NumQuestionsPerSubCategory: 1},
+    }
+    batchSvc := NewBatchService(mockQuizRepo, mockCategoryRepo, mockEmbeddingService, mockQuizGenSvc, cfg, logger) // Updated argument
+    ctx := context.Background()
+    subCategoryID1 := "subCatSaveErr"
+
+    generatedQuiz1 := &domain.NewQuizData{Question: "Q Save Err", ModelAnswer: "A", Keywords: []string{"k"}, Difficulty: "easy"}
+    embeddingForGeneratedQ1 := []float32{0.1, 0.2, 0.3}
+    expectedError := errors.New("save failed")
+
+    mockQuizRepo.On("GetAllSubCategories", ctx).Return([]string{subCategoryID1}, nil).Once()
+    mockQuizRepo.On("GetQuizzesBySubCategory", ctx, subCategoryID1).Return([]*domain.Quiz{}, nil).Once()
+    mockQuizGenSvc.On("GenerateQuizCandidates", ctx, subCategoryID1, []string{}, 1).Return([]*domain.NewQuizData{generatedQuiz1}, nil).Once() // Updated mock call
+    mockEmbeddingService.On("Generate", ctx, generatedQuiz1.Question).Return(embeddingForGeneratedQ1, nil).Once()
+    mockQuizRepo.On("SaveQuiz", ctx, mock.MatchedBy(func(quiz *domain.Quiz) bool {
+        return quiz.Question == generatedQuiz1.Question
+    })).Return(expectedError).Once()
+
+    // Service logs and continues
+    err := batchSvc.GenerateNewQuizzesAndSave(ctx)
+    assert.NoError(t, err) // Batch continues
+
+    mockQuizRepo.AssertExpectations(t)
+    mockQuizGenSvc.AssertExpectations(t) // Updated mock
+    mockEmbeddingService.AssertExpectations(t)
+}
+
+// TODO: Add TestGenerateNewQuizzesAndSave_Error_EmbeddingServiceFailsOnExistingQuiz if caching is off or for first load
+// This test would be similar to FailsOnNewQuiz but the error would come from embedding an existing quiz.
+// The current service logic might make this hard to distinguish in its effect if it simply continues.
+
+// Note on util.CosineSimilarity:
+// It's directly used. If it were an interface, it could be mocked.
+// For testing specific similarity values, you can control the embeddings returned by MockEmbeddingService.
+// For example, make two embeddings identical to force high similarity, or very different for low similarity.
+// This is demonstrated in TestGenerateNewQuizzesAndSave_Success_SomeSimilarQuizzes.
+
+// Note on SubCategoryName for LLM:
+// The test currently passes subCategoryID as subCategoryName to the LLM mock.
+// If the actual service needed to fetch the name, CategoryRepository would need mocking and usage.
+// The current batch_service.go uses subCategoryID directly.
+// `subCategoryNameForLLM := subCategoryID`
+// This means the QuizGenerationService mock should expect subCategoryID as the subCategoryName argument.
+// The tests reflect this by using subCategoryID in `mockQuizGenSvc.On("GenerateQuizCandidates", ctx, subCategoryID1, ...)`
+
+// Helper for creating a basic config for tests
+func getTestConfig() *config.Config {
+	return &config.Config{
+		Embedding: config.EmbeddingConfig{
+			SimilarityThreshold: 0.9,
+		},
+		Batch: config.BatchConfig{
+			NumQuestionsPerSubCategory: 2,
+		},
+		// Add other necessary fields if your service starts using them
+	}
+}
+
+// Helper for creating a test logger
+func getTestLogger() *zap.Logger {
+	logger, _ := zap.NewDevelopment() // Or zap.NewNop() for less output
+	return logger
+}
+
+// Example of a more structured test table (can be used for some error cases or variations)
+/*
+func TestGenerateNewQuizzesAndSave_TableDriven(t *testing.T) {
+	tests := []struct {
+		name          string
+		setupMocks    func(qr *MockQuizRepository, cr *MockCategoryRepository, es *MockEmbeddingService, qgs *MockQuizGenerationService) // Updated param type
+		expectedError bool
+		// ... other fields to assert ...
+	}{
+		// ... test cases ...
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockQuizRepo := new(MockQuizRepository)
+			mockCategoryRepo := new(MockCategoryRepository)
+			mockEmbeddingService := new(MockEmbeddingService)
+			mockQuizGenSvc := new(MockQuizGenerationService) // Renamed
+
+			logger := getTestLogger()
+			cfg := getTestConfig()
+
+			if tt.setupMocks != nil {
+				tt.setupMocks(mockQuizRepo, mockCategoryRepo, mockEmbeddingService, mockQuizGenSvc) // Updated argument
+			}
+
+			batchSvc := NewBatchService(mockQuizRepo, mockCategoryRepo, mockEmbeddingService, mockQuizGenSvc, cfg, logger) // Updated argument
+			err := batchSvc.GenerateNewQuizzesAndSave(context.Background())
+
+			if tt.expectedError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+			// Add more assertions based on tt.fields
+			mockQuizRepo.AssertExpectations(t)
+			mockCategoryRepo.AssertExpectations(t)
+			mockEmbeddingService.AssertExpectations(t)
+			mockQuizGenSvc.AssertExpectations(t) // Updated mock
+		})
+	}
+}
+*/
+
+// The actual CosineSimilarity from util is used.
+// If there was a desire to mock it, it would require util to expose an interface
+// or to use a more advanced mocking technique like monkey patching (generally discouraged).
+// Controlling the inputs (embeddings) to the real CosineSimilarity function is the current approach.
+// The tests `TestGenerateNewQuizzesAndSave_Success_NewUniqueQuizzes` and
+// `TestGenerateNewQuizzesAndSave_Success_SomeSimilarQuizzes` demonstrate this by providing
+// specific mock embeddings.
+
+// Ensure all required methods for QuizRepository are present in the mock
+var _ domain.QuizRepository = (*MockQuizRepository)(nil)
+var _ domain.CategoryRepository = (*MockCategoryRepository)(nil)
+var _ domain.EmbeddingService = (*MockEmbeddingService)(nil)
+var _ domain.QuizGenerationService = (*MockQuizGenerationService)(nil) // Updated static assertion


### PR DESCRIPTION
This commit refactors the batch quiz generation process to introduce a dedicated QuizGenerationService, decoupling the BatchService from direct LLM client interactions. This change is based on your feedback to improve separation of concerns.

Key changes:

-   **New Interface (`internal/domain/quizgen.go`):**
    Introduced `domain.QuizGenerationService` with a method
    `GenerateQuizCandidates` to abstract the process of generating quiz
    data from an LLM.

-   **New Service Implementation (`internal/adapter/quizgen/gemini_quiz_generator.go`):**
    -   The previous `GeminiLangchainAdapter` has been refactored into
        `GeminiQuizGenerator`, which now implements the
        `QuizGenerationService` interface.
    -   This service encapsulates prompt construction and parsing of the
        (simulated) LLM JSON response.
    -   The old `domain.LLMClient` interface and `internal/adapter/llm`
        directory have been removed.

-   **Refactored `BatchService` (`internal/service/batch_service.go`):**
    -   Now depends on `domain.QuizGenerationService` instead of the
        previous generic LLM client interface.
    -   Calls `quizGenSvc.GenerateQuizCandidates` to obtain new quiz data.

-   **Updated `main.go` (`cmd/batch_add_questions/main.go`):**
    -   The main application entry point now initializes
        `GeminiQuizGenerator` and injects it into `BatchService`.

-   **Updated Unit Tests:**
    -   `internal/service/batch_service_test.go` now mocks
        `QuizGenerationService`.
    -   Added new unit tests for `GeminiQuizGenerator` in
        `internal/adapter/quizgen/gemini_quiz_generator_test.go`,
        focusing on constructor logic and parsing of simulated LLM responses.

This refactoring enhances the modularity and testability of the system by clearly separating the quiz generation logic from the batch orchestration logic.