### PR TITLE
Refactor: Align backend with Port and Adapter pattern.

### DIFF
--- a/internal/domain/user.go
+++ b/internal/domain/user.go
@@ -1,7 +1,10 @@
 package domain
 
 import (
+	"context"
 	"time"
+
+	"quiz-byte/internal/dto"
 )
 
 // User represents a domain user object
@@ -36,4 +39,38 @@ func (u *User) Validate() error {
 		return NewValidationError("email is required")
 	}
 	return nil
+}
+
+// UserQuizAttempt represents a user's attempt at a quiz question.
+type UserQuizAttempt struct {
+	ID                string
+	UserID            string
+	QuizID            string
+	UserAnswer        string // Assuming string, can be *string if nullable
+	LLMScore          float64
+	LLMExplanation    string // Assuming string, can be *string if nullable
+	LLMKeywordMatches []string
+	LLMCompleteness   float64
+	LLMRelevance      float64
+	LLMAccuracy       float64
+	IsCorrect         bool
+	AttemptedAt       time.Time
+	CreatedAt         time.Time
+	UpdatedAt         time.Time
+	DeletedAt         *time.Time
+}
+
+// UserRepository defines the interface for user data persistence.
+type UserRepository interface {
+	CreateUser(ctx context.Context, user *User) error
+	GetUserByGoogleID(ctx context.Context, googleID string) (*User, error)
+	GetUserByID(ctx context.Context, userID string) (*User, error)
+	UpdateUser(ctx context.Context, user *User) error
+}
+
+// UserQuizAttemptRepository defines the interface for user quiz attempt data persistence.
+type UserQuizAttemptRepository interface {
+	CreateAttempt(ctx context.Context, attempt *UserQuizAttempt) error
+	GetAttemptsByUserID(ctx context.Context, userID string, filters dto.AttemptFilters, pagination dto.Pagination) ([]UserQuizAttempt, int, error)
+	GetIncorrectAttemptsByUserID(ctx context.Context, userID string, filters dto.AttemptFilters, pagination dto.Pagination) ([]UserQuizAttempt, int, error)
 }

--- a/internal/dto/user_dto.go
+++ b/internal/dto/user_dto.go
@@ -120,3 +120,12 @@ type QuizRecommendationsResponse struct {
 	Recommendations []QuizRecommendationItem `json:"recommendations"`
 	// Context string `json:"context,omitempty"` // Future: why these were recommended
 }
+
+// AuthenticatedUser represents the user data returned upon successful authentication
+// by the AuthService, intended for internal use before constructing the final HTTP response.
+type AuthenticatedUser struct {
+	ID                string `json:"id"`
+	Email             string `json:"email"`
+	Name              string `json:"name,omitempty"`
+	ProfilePictureURL string `json:"profile_picture_url,omitempty"`
+}


### PR DESCRIPTION
This commit incorporates several key refactoring changes to align the Quiz Byte backend more closely with the Port and Adapter (Hexagonal) architectural pattern. The primary goals were to enhance separation of concerns, improve testability, and increase flexibility.

Key changes include:

1.  **Domain Repository Interfaces:**
    *   Defined `UserRepository` and `UserQuizAttemptRepository` interfaces
        in `internal/domain/user.go`.
    *   Defined `domain.UserQuizAttempt` struct.

2.  **Repository Adapter Updates:**
    *   `internal/repository/user_repository.go` (sqlxUserRepository) now
        implements `domain.UserRepository`, operating with `domain.User`
        entities and handling internal mapping to/from `models.User`.
    *   `internal/repository/user_quiz_attempt_repository.go`
        (sqlxUserQuizAttemptRepository) now implements
        `domain.UserQuizAttemptRepository`, operating with
        `domain.UserQuizAttempt` and mapping to/from
        `models.UserQuizAttempt`.

3.  **Application Service Updates:**
    *   `AuthService` and `UserService` now depend on the new domain
        repository interfaces (`domain.UserRepository`,
        `domain.UserQuizAttemptRepository`).
    *   Services internally use domain entities (`domain.User`,
        `domain.UserQuizAttempt`).
    *   Note: A temporary issue with OAuth token persistence in `AuthService`
        was identified, as `domain.User` does not store token fields.
        This will require a follow-up.

4.  **AnswerEvaluator Relocation:**
    *   The `AnswerEvaluator` interface is confirmed to be correctly located
        in `internal/domain/evaluator.go`.
    *   Its implementation, `llmEvaluator`, was moved from
        `internal/domain/llm_evaluator.go` to
        `internal/adapter/evaluator/llm_evaluator.go` to better reflect
        its role as an adapter.

5.  **DTO and Service Data Flow:**
    *   `AuthService.HandleGoogleCallback` now returns
        `*dto.AuthenticatedUser` instead of `*models.User`, ensuring
        database models are not leaked to the handler layer.
    *   Other services (`UserService`) were confirmed to use DTOs appropriately
        at their boundaries.

6.  **Configuration in Services (Lower Priority):**
    *   `QuizService` and `AnswerCacheService` were refactored to accept
        specific, parsed configuration values (like TTLs as `time.Duration`)
        instead of the entire `config.Config` object, reducing coupling.
    *   `cmd/api/main.go` was updated to parse these values and pass them
        during service initialization.

This set of changes lays a strong foundation for a more maintainable and testable backend system. The next step, which will be handled separately, is to thoroughly review and update unit and integration tests to ensure all unit tests pass and integration tests compile without errors.