### PR TITLE
feat: Implement anonymous user quiz access and personalized services

### DIFF
--- a/internal/handler/quiz_handler_test.go
+++ b/internal/handler/quiz_handler_test.go
@@ -1,0 +1,246 @@
+package handler_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http/httptest"
+	"quiz-byte/internal/domain"
+	"quiz-byte/internal/dto"
+	"quiz-byte/internal/handler"
+	"quiz-byte/internal/middleware"
+	"quiz-byte/internal/service"
+	// "quiz-byte/internal/util" // Not directly used in test, but by code under test
+	"testing"
+	"time"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/stretchr/testify/assert"
+)
+
+// --- Manual Mocks ---
+
+// MockQuizService
+type MockQuizService struct {
+	GetRandomQuizFunc     func(subCategory string) (*dto.QuizResponse, error)
+	CheckAnswerFunc       func(req *dto.CheckAnswerRequest) (*dto.CheckAnswerResponse, error)
+	GetAllSubCategoriesFunc func() ([]string, error)
+	GetBulkQuizzesFunc    func(req *dto.BulkQuizzesRequest) (*dto.BulkQuizzesResponse, error)
+}
+
+func (m *MockQuizService) GetRandomQuiz(subCategory string) (*dto.QuizResponse, error) {
+	if m.GetRandomQuizFunc != nil {
+		return m.GetRandomQuizFunc(subCategory)
+	}
+	panic("MockQuizService.GetRandomQuizFunc not implemented")
+}
+func (m *MockQuizService) CheckAnswer(req *dto.CheckAnswerRequest) (*dto.CheckAnswerResponse, error) {
+	if m.CheckAnswerFunc != nil {
+		return m.CheckAnswerFunc(req)
+	}
+	panic("MockQuizService.CheckAnswerFunc not implemented")
+}
+func (m *MockQuizService) GetAllSubCategories() ([]string, error) {
+	if m.GetAllSubCategoriesFunc != nil {
+		return m.GetAllSubCategoriesFunc()
+	}
+	panic("MockQuizService.GetAllSubCategoriesFunc not implemented")
+}
+func (m *MockQuizService) GetBulkQuizzes(req *dto.BulkQuizzesRequest) (*dto.BulkQuizzesResponse, error) {
+	if m.GetBulkQuizzesFunc != nil {
+		return m.GetBulkQuizzesFunc(req)
+	}
+	panic("MockQuizService.GetBulkQuizzesFunc not implemented")
+}
+
+// MockUserService
+type MockUserService struct {
+	GetUserProfileFunc        func(ctx context.Context, userID string) (*dto.UserProfileResponse, error)
+	RecordQuizAttemptFunc     func(ctx context.Context, userID string, quizID string, userAnswer string, evalResult *domain.Answer) error
+	GetUserQuizAttemptsFunc   func(ctx context.Context, userID string, filters dto.AttemptFilters, pagination dto.Pagination) (*dto.UserQuizAttemptsResponse, error)
+	GetUserIncorrectAnswersFunc func(ctx context.Context, userID string, filters dto.AttemptFilters, pagination dto.Pagination) (*dto.UserIncorrectAnswersResponse, error)
+	GetUserRecommendationsFunc func(ctx context.Context, userID string, limit int, optionalSubCategoryID string) (*dto.QuizRecommendationsResponse, error)
+}
+
+func (m *MockUserService) GetUserProfile(ctx context.Context, userID string) (*dto.UserProfileResponse, error) {
+	if m.GetUserProfileFunc != nil {
+		return m.GetUserProfileFunc(ctx, userID)
+	}
+	panic("MockUserService.GetUserProfileFunc not implemented")
+}
+func (m *MockUserService) RecordQuizAttempt(ctx context.Context, userID string, quizID string, userAnswer string, evalResult *domain.Answer) error {
+	if m.RecordQuizAttemptFunc != nil {
+		return m.RecordQuizAttemptFunc(ctx, userID, quizID, userAnswer, evalResult)
+	}
+	panic("MockUserService.RecordQuizAttemptFunc not implemented")
+}
+func (m *MockUserService) GetUserQuizAttempts(ctx context.Context, userID string, filters dto.AttemptFilters, pagination dto.Pagination) (*dto.UserQuizAttemptsResponse, error) {
+	if m.GetUserQuizAttemptsFunc != nil {
+		return m.GetUserQuizAttemptsFunc(ctx, userID, filters, pagination)
+	}
+	panic("MockUserService.GetUserQuizAttemptsFunc not implemented")
+}
+func (m *MockUserService) GetUserIncorrectAnswers(ctx context.Context, userID string, filters dto.AttemptFilters, pagination dto.Pagination) (*dto.UserIncorrectAnswersResponse, error) {
+	if m.GetUserIncorrectAnswersFunc != nil {
+		return m.GetUserIncorrectAnswersFunc(ctx, userID, filters, pagination)
+	}
+	panic("MockUserService.GetUserIncorrectAnswersFunc not implemented")
+}
+func (m *MockUserService) GetUserRecommendations(ctx context.Context, userID string, limit int, optionalSubCategoryID string) (*dto.QuizRecommendationsResponse, error) {
+	if m.GetUserRecommendationsFunc != nil {
+		return m.GetUserRecommendationsFunc(ctx, userID, limit, optionalSubCategoryID)
+	}
+	panic("MockUserService.GetUserRecommendationsFunc not implemented")
+}
+
+
+// MockAnonymousResultCacheService
+type MockAnonymousResultCacheService struct {
+	PutFunc func(ctx context.Context, requestID string, result *dto.CheckAnswerResponse) error
+	GetFunc func(ctx context.Context, requestID string) (*dto.CheckAnswerResponse, error)
+}
+
+func (m *MockAnonymousResultCacheService) Put(ctx context.Context, requestID string, result *dto.CheckAnswerResponse) error {
+	if m.PutFunc != nil {
+		return m.PutFunc(ctx, requestID, result)
+	}
+	panic("MockAnonymousResultCacheService.PutFunc not implemented")
+}
+func (m *MockAnonymousResultCacheService) Get(ctx context.Context, requestID string) (*dto.CheckAnswerResponse, error) {
+	if m.GetFunc != nil {
+		return m.GetFunc(ctx, requestID)
+	}
+	panic("MockAnonymousResultCacheService.GetFunc not implemented")
+}
+
+
+func TestQuizHandler_CheckAnswer(t *testing.T) {
+	var mockQuizSvc *MockQuizService
+	var mockUserSvc *MockUserService
+	var mockAnonCacheSvc *MockAnonymousResultCacheService
+	var quizHandler *handler.QuizHandler
+	var app *fiber.App // Fiber app for context creation
+
+	setup := func() {
+		mockQuizSvc = &MockQuizService{}
+		mockUserSvc = &MockUserService{}
+		mockAnonCacheSvc = &MockAnonymousResultCacheService{}
+		quizHandler = handler.NewQuizHandler(mockQuizSvc, mockUserSvc, mockAnonCacheSvc)
+		app = fiber.New()
+	}
+
+	commonCheckAnswerRequest := dto.CheckAnswerRequest{
+		QuizID:     "quiz123",
+		UserAnswer: "My answer",
+	}
+	commonDomainResult := &dto.CheckAnswerResponse{
+		Score:       0.8,
+		Explanation: "Good work!",
+		// Fill other fields as necessary, matching what quizService.CheckAnswer would return
+		KeywordMatches: []string{"keyword1"},
+		Completeness:   0.9,
+		Relevance:      0.85,
+		Accuracy:       0.75,
+		ModelAnswer:    "This is the model answer.",
+	}
+
+	t.Run("Authenticated User", func(t *testing.T) {
+		setup()
+		userID := "userTest123"
+		recordAttemptCalled := false
+		var recordedUserID, recordedQuizID, recordedUserAnswer string
+
+
+		mockQuizSvc.CheckAnswerFunc = func(req *dto.CheckAnswerRequest) (*dto.CheckAnswerResponse, error) {
+			assert.Equal(t, commonCheckAnswerRequest.QuizID, req.QuizID)
+			assert.Equal(t, commonCheckAnswerRequest.UserAnswer, req.UserAnswer)
+			return commonDomainResult, nil
+		}
+		mockUserSvc.RecordQuizAttemptFunc = func(ctx context.Context, uID string, qID string, uAnswer string, evalResult *domain.Answer) error {
+			recordAttemptCalled = true
+			recordedUserID = uID
+			recordedQuizID = qID
+			recordedUserAnswer = uAnswer
+			assert.Equal(t, commonDomainResult.Score, evalResult.Score)
+			assert.WithinDuration(t, time.Now(), evalResult.AnsweredAt, 5*time.Second) // Check if AnsweredAt is recent
+			return nil
+		}
+		// Ensure Put is not called by setting it to fail the test if it is
+		mockAnonCacheSvc.PutFunc = func(ctx context.Context, requestID string, result *dto.CheckAnswerResponse) error {
+			assert.Fail(t, "AnonymousResultCacheService.Put should not be called for authenticated user")
+			return errors.New("Put should not be called")
+		}
+
+		c := app.AcquireCtx(&fiber.Ctx{})
+		defer app.ReleaseCtx(c)
+		c.Locals(middleware.UserIDKey, userID)
+
+		reqBodyBytes, _ := json.Marshal(commonCheckAnswerRequest)
+		httpRequest := httptest.NewRequest("POST", "/quiz/check", bytes.NewReader(reqBodyBytes))
+		httpRequest.Header.Set("Content-Type", "application/json")
+		c.SetReq(httpRequest) // Associate httptest request with Fiber context
+
+		err := quizHandler.CheckAnswer(c)
+
+		assert.NoError(t, err)
+		assert.True(t, recordAttemptCalled, "UserService.RecordQuizAttempt should be called for authenticated user")
+		assert.Equal(t, userID, recordedUserID)
+		assert.Equal(t, commonCheckAnswerRequest.QuizID, recordedQuizID)
+		assert.Equal(t, commonCheckAnswerRequest.UserAnswer, recordedUserAnswer)
+
+		// Check response written to Fiber context
+		assert.Equal(t, fiber.StatusOK, c.Response().StatusCode()) // Default status is 200 if not set otherwise
+		var respBody dto.CheckAnswerResponse
+		err = json.Unmarshal(c.Response().Body(), &respBody)
+		assert.NoError(t, err)
+		assert.Equal(t, commonDomainResult.Score, respBody.Score)
+		assert.Equal(t, commonDomainResult.Explanation, respBody.Explanation)
+	})
+
+	t.Run("Anonymous User", func(t *testing.T) {
+		setup()
+		anonCachePutCalled := false
+		var cachedResult *dto.CheckAnswerResponse
+
+		mockQuizSvc.CheckAnswerFunc = func(req *dto.CheckAnswerRequest) (*dto.CheckAnswerResponse, error) {
+			assert.Equal(t, commonCheckAnswerRequest.QuizID, req.QuizID)
+			assert.Equal(t, commonCheckAnswerRequest.UserAnswer, req.UserAnswer)
+			return commonDomainResult, nil
+		}
+		// Ensure RecordQuizAttempt is not called
+		mockUserSvc.RecordQuizAttemptFunc = func(ctx context.Context, userID string, quizID string, userAnswer string, evalResult *domain.Answer) error {
+			assert.Fail(t, "UserService.RecordQuizAttempt should not be called for anonymous user")
+			return errors.New("RecordQuizAttempt should not be called")
+		}
+		mockAnonCacheSvc.PutFunc = func(ctx context.Context, requestID string, result *dto.CheckAnswerResponse) error {
+			anonCachePutCalled = true
+			cachedResult = result
+			assert.NotEmpty(t, requestID, "RequestID for cache should not be empty for anonymous user")
+			assert.IsType(t, "string", requestID)
+			assert.Equal(t, commonDomainResult, result)
+			return nil
+		}
+
+		c := app.AcquireCtx(&fiber.Ctx{})
+		defer app.ReleaseCtx(c)
+		// No UserIDKey set in c.Locals for anonymous user
+
+		reqBodyBytes, _ := json.Marshal(commonCheckAnswerRequest)
+		httpRequest := httptest.NewRequest("POST", "/quiz/check", bytes.NewReader(reqBodyBytes))
+		httpRequest.Header.Set("Content-Type", "application/json")
+		c.SetReq(httpRequest)
+
+		err := quizHandler.CheckAnswer(c)
+
+		assert.NoError(t, err)
+		assert.True(t, anonCachePutCalled, "AnonymousResultCacheService.Put should be called for anonymous user")
+
+		assert.Equal(t, fiber.StatusOK, c.Response().StatusCode())
+		var respBody dto.CheckAnswerResponse
+		err = json.Unmarshal(c.Response().Body(), &respBody)
+		assert.NoError(t, err)
+		assert.Equal(t, commonDomainResult.Score, respBody.Score)
+		assert.Equal(t, commonDomainResult.Explanation, respBody.Explanation)
+	})
+}

--- a/internal/middleware/auth_middleware_test.go
+++ b/internal/middleware/auth_middleware_test.go
@@ -1,0 +1,170 @@
+package middleware_test
+
+import (
+	"context"
+	"errors"
+	"net/http/httptest"
+	// Adjust the import path if auth.Claims is located elsewhere, e.g., internal/auth/claims
+	"quiz-byte/internal/domain/auth"
+	"quiz-byte/internal/middleware"
+	"quiz-byte/internal/service" // For the AuthService interface
+	"testing"
+	"time"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/golang-jwt/jwt/v5" // For jwt.RegisteredClaims
+	"github.com/stretchr/testify/assert"
+	// "go.uber.org/mock/gomock" // Not using generated mocks directly in this step
+)
+
+// Manual MockAuthService for testing middleware.AuthService interface
+type ManualMockAuthService struct {
+	ValidateJWTFunc func(ctx context.Context, tokenString string) (*auth.Claims, error)
+}
+
+func (m *ManualMockAuthService) GenerateJWT(userID, tokenType string) (string, error) {
+	panic("not implemented in mock")
+}
+
+func (m *ManualMockAuthService) ValidateJWT(ctx context.Context, tokenString string) (*auth.Claims, error) {
+	if m.ValidateJWTFunc != nil {
+		return m.ValidateJWTFunc(ctx, tokenString)
+	}
+	return nil, errors.New("ValidateJWTFunc not set on mock")
+}
+
+func (m *ManualMockAuthService) GenerateAndStoreTokens(ctx context.Context, userID string, prevRefreshTokenID string) (accessToken string, refreshToken string, err error) {
+	panic("not implemented in mock")
+}
+
+func (m *ManualMockAuthService) ValidateAndRefreshTokens(ctx context.Context, oldAccessTokenString string, oldRefreshTokenString string) (newAccessToken string, newRefreshToken string, err error) {
+	panic("not implemented in mock")
+}
+
+func (m *ManualMockAuthService) RevokeToken(ctx context.Context, tokenID string, tokenType string) error {
+	panic("not implemented in mock")
+}
+
+func (m *ManualMockAuthService) GetUserIDFromToken(ctx context.Context, tokenString string) (string, error) {
+	panic("not implemented in mock")
+}
+
+
+func TestOptionalAuth(t *testing.T) {
+
+	mockAuthSvc := &ManualMockAuthService{}
+
+	tests := []struct {
+		name                string
+		authHeader          string
+		setupMock           func(mockSvc *ManualMockAuthService)
+		expectedStatus      int
+		expectedUserIDLocal interface{}
+		expectNextCalled    bool
+	}{
+		{
+			name:           "No Auth Header",
+			authHeader:     "",
+			setupMock:      func(mockSvc *ManualMockAuthService) {},
+			expectedStatus: fiber.StatusOK,
+			expectedUserIDLocal: nil,
+			expectNextCalled: true,
+		},
+		{
+			name:       "Valid Access Token",
+			authHeader: "Bearer valid_access_token",
+			setupMock: func(mockSvc *ManualMockAuthService) {
+				mockSvc.ValidateJWTFunc = func(ctx context.Context, tokenString string) (*auth.Claims, error) {
+					assert.Equal(t, "valid_access_token", tokenString)
+					return &auth.Claims{UserID: "user123", TokenType: "access", RegisteredClaims: jwt.RegisteredClaims{ExpiresAt: jwt.NewNumericDate(time.Now().Add(1 * time.Hour))}}, nil
+				}
+			},
+			expectedStatus: fiber.StatusOK,
+			expectedUserIDLocal: "user123",
+			expectNextCalled: true,
+		},
+		{
+			name:       "Invalid Token (validation error)",
+			authHeader: "Bearer invalid_token",
+			setupMock: func(mockSvc *ManualMockAuthService) {
+				mockSvc.ValidateJWTFunc = func(ctx context.Context, tokenString string) (*auth.Claims, error) {
+					assert.Equal(t, "invalid_token", tokenString)
+					return nil, errors.New("invalid token")
+				}
+			},
+			expectedStatus: fiber.StatusOK,
+			expectedUserIDLocal: nil,
+			expectNextCalled: true,
+		},
+		{
+			name:       "Valid Refresh Token instead of Access",
+			authHeader: "Bearer valid_refresh_token",
+			setupMock: func(mockSvc *ManualMockAuthService) {
+				mockSvc.ValidateJWTFunc = func(ctx context.Context, tokenString string) (*auth.Claims, error) {
+					assert.Equal(t, "valid_refresh_token", tokenString)
+					// TokenType is "refresh"
+					return &auth.Claims{UserID: "user456", TokenType: "refresh", RegisteredClaims: jwt.RegisteredClaims{ExpiresAt: jwt.NewNumericDate(time.Now().Add(1 * time.Hour))}}, nil
+				}
+			},
+			expectedStatus: fiber.StatusOK,
+			expectedUserIDLocal: nil,
+			expectNextCalled: true,
+		},
+		{
+			name:           "Malformed Auth Header - No Bearer",
+			authHeader:     "Basic some_token",
+			setupMock:      func(mockSvc *ManualMockAuthService) {},
+			expectedStatus: fiber.StatusOK,
+			expectedUserIDLocal: nil,
+			expectNextCalled: true,
+		},
+		{
+			name:       "Malformed Auth Header - Bearer No Token",
+			authHeader: "Bearer ",
+			setupMock:      func(mockSvc *ManualMockAuthService) {},
+			expectedStatus: fiber.StatusOK,
+			expectedUserIDLocal: nil,
+			expectNextCalled: true,
+		},
+		{
+			name:       "Empty Token String",
+			authHeader: "Bearer ", // Covered by "Malformed Auth Header - Bearer No Token" effectively
+			setupMock:      func(mockSvc *ManualMockAuthService) {},
+			expectedStatus: fiber.StatusOK,
+			expectedUserIDLocal: nil,
+			expectNextCalled: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			app := fiber.New() // Create new app for each test to reset state
+			tc.setupMock(mockAuthSvc)
+
+			nextHandlerCalled := false
+			var userIDLocalValue interface{}
+
+			// Setup route with middleware and a handler to capture locals and check if called
+			app.Get("/test_optional_auth", middleware.OptionalAuth(mockAuthSvc), func(c *fiber.Ctx) error {
+				nextHandlerCalled = true
+				userIDLocalValue = c.Locals(middleware.UserIDKey)
+				return c.SendStatus(fiber.StatusOK)
+			})
+
+			req := httptest.NewRequest("GET", "/test_optional_auth", nil)
+			if tc.authHeader != "" {
+				req.Header.Set("Authorization", tc.authHeader)
+			}
+
+			resp, err := app.Test(req, -1)
+
+			assert.NoError(t, err, "app.Test should not return an error")
+			if err == nil { // Only assert status if no app.Test error
+				assert.Equal(t, tc.expectedStatus, resp.StatusCode, "HTTP status code mismatch")
+			}
+
+			assert.True(t, nextHandlerCalled, "Next handler was not called")
+			assert.Equal(t, tc.expectedUserIDLocal, userIDLocalValue, "UserID in Ctx.Locals mismatch")
+		})
+	}
+}

--- a/internal/service/anonymous_result_cache.go
+++ b/internal/service/anonymous_result_cache.go
@@ -1,0 +1,111 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"quiz-byte/internal/domain"
+	"quiz-byte/internal/dto"
+	"quiz-byte/internal/logger"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+const anonymousResultCachePrefix = "anonymous_result:"
+
+// ErrAnonymousResultNotFound is returned when a cached result is not found.
+var ErrAnonymousResultNotFound = errors.New("anonymous result not found in cache")
+
+// AnonymousResultCacheService defines the interface for caching anonymous user quiz results.
+type AnonymousResultCacheService interface {
+	Put(ctx context.Context, requestID string, result *dto.CheckAnswerResponse) error
+	Get(ctx context.Context, requestID string) (*dto.CheckAnswerResponse, error)
+}
+
+// anonymousResultCacheServiceImpl implements AnonymousResultCacheService using a generic cache.
+type anonymousResultCacheServiceImpl struct {
+	cache domain.Cache
+	ttl   time.Duration
+}
+
+// NewAnonymousResultCacheService creates a new instance of anonymousResultCacheServiceImpl.
+func NewAnonymousResultCacheService(cache domain.Cache, ttl time.Duration) AnonymousResultCacheService {
+	if cache == nil {
+		// Fallback to a no-op implementation if cache is nil to prevent panics
+		logger.Get().Warn("AnonymousResultCacheService initialized with nil cache. Service will be no-op.")
+		return &noopAnonymousResultCacheService{}
+	}
+	return &anonymousResultCacheServiceImpl{
+		cache: cache,
+		ttl:   ttl,
+	}
+}
+
+func (s *anonymousResultCacheServiceImpl) cacheKey(requestID string) string {
+	return anonymousResultCachePrefix + requestID
+}
+
+// Put stores the quiz result for an anonymous user in the cache.
+func (s *anonymousResultCacheServiceImpl) Put(ctx context.Context, requestID string, result *dto.CheckAnswerResponse) error {
+	if result == nil {
+		return errors.New("cannot cache nil result")
+	}
+
+	key := s.cacheKey(requestID)
+	data, err := json.Marshal(result)
+	if err != nil {
+		logger.Get().Error("Failed to marshal anonymous result for caching", zap.Error(err), zap.String("requestID", requestID))
+		return fmt.Errorf("failed to marshal result: %w", err)
+	}
+
+	err = s.cache.Set(ctx, key, data, s.ttl)
+	if err != nil {
+		logger.Get().Error("Failed to cache anonymous result", zap.Error(err), zap.String("key", key))
+		return fmt.Errorf("failed to set cache: %w", err)
+	}
+	logger.Get().Debug("Successfully cached anonymous result", zap.String("key", key), zap.Duration("ttl", s.ttl))
+	return nil
+}
+
+// Get retrieves the quiz result for an anonymous user from the cache.
+func (s *anonymousResultCacheServiceImpl) Get(ctx context.Context, requestID string) (*dto.CheckAnswerResponse, error) {
+	key := s.cacheKey(requestID)
+	data, err := s.cache.Get(ctx, key)
+	if err != nil {
+		if errors.Is(err, domain.ErrCacheMiss) { // Assuming domain.Cache returns a specific error for cache miss
+			logger.Get().Debug("Anonymous result cache miss", zap.String("key", key))
+			return nil, ErrAnonymousResultNotFound // Return specific error for not found
+		}
+		logger.Get().Error("Failed to get anonymous result from cache", zap.Error(err), zap.String("key", key))
+		return nil, fmt.Errorf("failed to get from cache: %w", err)
+	}
+
+	if data == nil { // Should be handled by domain.ErrCacheMiss, but as a safeguard
+		logger.Get().Debug("Anonymous result cache miss (nil data)", zap.String("key", key))
+		return nil, ErrAnonymousResultNotFound
+	}
+
+	var result dto.CheckAnswerResponse
+	if err := json.Unmarshal(data, &result); err != nil {
+		logger.Get().Error("Failed to unmarshal anonymous result from cache", zap.Error(err), zap.String("key", key))
+		return nil, fmt.Errorf("failed to unmarshal result: %w", err)
+	}
+
+	logger.Get().Debug("Successfully retrieved anonymous result from cache", zap.String("key", key))
+	return &result, nil
+}
+
+// noopAnonymousResultCacheService is a no-op implementation for when caching is disabled or fails to initialize.
+type noopAnonymousResultCacheService struct{}
+
+func (s *noopAnonymousResultCacheService) Put(ctx context.Context, requestID string, result *dto.CheckAnswerResponse) error {
+	logger.Get().Debug("No-op AnonymousResultCacheService: Put called", zap.String("requestID", requestID))
+	return nil
+}
+
+func (s *noopAnonymousResultCacheService) Get(ctx context.Context, requestID string) (*dto.CheckAnswerResponse, error) {
+	logger.Get().Debug("No-op AnonymousResultCacheService: Get called", zap.String("requestID", requestID))
+	return nil, ErrAnonymousResultNotFound
+}

--- a/internal/service/anonymous_result_cache_test.go
+++ b/internal/service/anonymous_result_cache_test.go
@@ -1,0 +1,171 @@
+package service_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"quiz-byte/internal/domain"
+	"quiz-byte/internal/dto"
+	"quiz-byte/internal/service"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	// "go.uber.org/mock/gomock" // Not using generated mocks directly
+)
+
+// ManualMockCache for domain.Cache interface
+type ManualMockCache struct {
+	GetFunc    func(ctx context.Context, key string) ([]byte, error)
+	SetFunc    func(ctx context.Context, key string, value interface{}, ttl time.Duration) error
+	DeleteFunc func(ctx context.Context, key string) error
+	// Add other methods if AnonymousResultCacheService uses them
+}
+
+func (m *ManualMockCache) Get(ctx context.Context, key string) ([]byte, error) {
+	if m.GetFunc != nil {
+		return m.GetFunc(ctx, key)
+	}
+	return nil, errors.New("GetFunc not set")
+}
+
+func (m *ManualMockCache) Set(ctx context.Context, key string, value interface{}, ttl time.Duration) error {
+	if m.SetFunc != nil {
+		// The service serializes to []byte before calling cache.Set
+		// So, the mock should expect []byte if it's strict about type.
+		// For this test, we'll assume the service passes []byte.
+		return m.SetFunc(ctx, key, value, ttl)
+	}
+	return errors.New("SetFunc not set")
+}
+
+func (m *ManualMockCache) Delete(ctx context.Context, key string) error {
+	if m.DeleteFunc != nil {
+		return m.DeleteFunc(ctx, key)
+	}
+	return errors.New("DeleteFunc not set")
+}
+
+func (m *ManualMockCache) GetKeysByPrefix(ctx context.Context, prefix string) ([]string, error) {
+	panic("not implemented in mock")
+}
+
+func (m *ManualMockCache) DeleteByPrefix(ctx context.Context, prefix string) error {
+	panic("not implemented in mock")
+}
+
+
+func TestAnonymousResultCacheServiceImpl_Put(t *testing.T) {
+	mockCache := &ManualMockCache{}
+	ttl := 5 * time.Minute
+	cacheService := service.NewAnonymousResultCacheService(mockCache, ttl)
+	ctx := context.Background()
+
+	requestID := "req123"
+	result := &dto.CheckAnswerResponse{Score: 0.8, Explanation: "Good job!"}
+
+	expectedKey := "anonymous_result:" + requestID
+	expectedData, _ := json.Marshal(result)
+
+	mockCache.SetFunc = func(ctx context.Context, key string, value interface{}, duration time.Duration) error {
+		assert.Equal(t, expectedKey, key)
+		assert.Equal(t, expectedData, value.([]byte)) // Service should pass []byte
+		assert.Equal(t, ttl, duration)
+		return nil
+	}
+
+	err := cacheService.Put(ctx, requestID, result)
+	assert.NoError(t, err)
+}
+
+func TestAnonymousResultCacheServiceImpl_Get(t *testing.T) {
+	mockCache := &ManualMockCache{}
+	ttl := 5 * time.Minute
+	cacheService := service.NewAnonymousResultCacheService(mockCache, ttl)
+	ctx := context.Background()
+
+	requestID := "req123"
+	expectedResult := &dto.CheckAnswerResponse{Score: 0.9, Explanation: "Excellent!"}
+	expectedKey := "anonymous_result:" + requestID
+
+	t.Run("Cache Hit", func(t *testing.T) {
+		jsonData, _ := json.Marshal(expectedResult)
+		mockCache.GetFunc = func(ctx context.Context, key string) ([]byte, error) {
+			assert.Equal(t, expectedKey, key)
+			return jsonData, nil
+		}
+
+		result, err := cacheService.Get(ctx, requestID)
+		assert.NoError(t, err)
+		assert.Equal(t, expectedResult, result)
+	})
+
+	t.Run("Cache Miss", func(t *testing.T) {
+		mockCache.GetFunc = func(ctx context.Context, key string) ([]byte, error) {
+			assert.Equal(t, expectedKey, key)
+			return nil, domain.ErrCacheMiss // Use the specific error from your domain package
+		}
+
+		result, err := cacheService.Get(ctx, requestID)
+		assert.Nil(t, result)
+		assert.Equal(t, service.ErrAnonymousResultNotFound, err)
+	})
+
+	t.Run("Cache Miss (nil data, nil error - less common but possible)", func(t *testing.T) {
+		mockCache.GetFunc = func(ctx context.Context, key string) ([]byte, error) {
+			assert.Equal(t, expectedKey, key)
+			return nil, nil // Simulate a cache returning nil data and nil error for a miss
+		}
+
+		result, err := cacheService.Get(ctx, requestID)
+		assert.Nil(t, result)
+		// The service implementation should consistently return ErrAnonymousResultNotFound for misses
+		assert.Equal(t, service.ErrAnonymousResultNotFound, err)
+	})
+
+
+	t.Run("Cache Error", func(t *testing.T) {
+		expectedErr := errors.New("some cache system error")
+		mockCache.GetFunc = func(ctx context.Context, key string) ([]byte, error) {
+			assert.Equal(t, expectedKey, key)
+			return nil, expectedErr
+		}
+
+		result, err := cacheService.Get(ctx, requestID)
+		assert.Nil(t, result)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), expectedErr.Error())
+	})
+
+	t.Run("Deserialization Error", func(t *testing.T) {
+		malformedJsonData := []byte("{score:0.5, explanation:'bad json'") // missing quotes
+		mockCache.GetFunc = func(ctx context.Context, key string) ([]byte, error) {
+			assert.Equal(t, expectedKey, key)
+			return malformedJsonData, nil
+		}
+
+		result, err := cacheService.Get(ctx, requestID)
+		assert.Nil(t, result)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to unmarshal result")
+	})
+}
+
+func TestNewAnonymousResultCacheService_NilCache(t *testing.T) {
+	ttl := 5 * time.Minute
+	// Initialize with nil cache
+	cacheService := service.NewAnonymousResultCacheService(nil, ttl)
+	ctx := context.Background()
+
+	requestID := "reqNoCache"
+	resultToPut := &dto.CheckAnswerResponse{Score: 0.7, Explanation: "Testing no-op"}
+
+	// Test Put on no-op service
+	errPut := cacheService.Put(ctx, requestID, resultToPut)
+	assert.NoError(t, errPut, "Put on no-op service should not error")
+
+	// Test Get on no-op service
+	retrievedResult, errGet := cacheService.Get(ctx, requestID)
+	assert.Nil(t, retrievedResult, "Get on no-op service should return nil result")
+	assert.Equal(t, service.ErrAnonymousResultNotFound, errGet, "Get on no-op service should return ErrAnonymousResultNotFound")
+}


### PR DESCRIPTION
This commit introduces support for anonymous (non-logged-in) users to participate in quizzes, alongside enhancements for personalized services for logged-in users, as per your requirements specification.

Key changes include:

1.  **Authentication Middleware:**
    *   Introduced `OptionalAuth` middleware: Allows routes to be accessible
        by both authenticated and anonymous users. It sets user context
        only if a valid token is provided.
    *   The existing `Protected` middleware remains for routes strictly
        requiring authentication.

2.  **API Handler Updates:**
    *   Quiz routes (`/api/quiz/*`, `/api/quizzes`) now use `OptionalAuth`.
    *   `QuizHandler.CheckAnswer` now conditionally records quiz attempts
        only for logged-in users.
    *   User-specific routes (`/api/users/me/*`) remain under `Protected`
        middleware.

3.  **Service Logic Adjustments:**
    *   `AnonymousResultCacheService`: Implemented a new service to cache
        quiz results (`dto.CheckAnswerResponse`) for anonymous users for a
        short duration (e.g., 5 minutes) in Redis. This fulfills FR-ANO-002.
    *   `QuizHandler.CheckAnswer` integrates with this service to cache
        results for anonymous submissions.
    *   The system ensures that anonymous users' quiz attempt details are
        not saved to the permanent database (FR-ANO-004).

4.  **Database and Repository:**
    *   No changes were required to the database schema or repositories
        for user attempts, as the existing `user_quiz_attempts` table
        (with a NOT NULL `user_id`) and application logic already prevent
        anonymous attempt storage.

5.  **Unit Tests:**
    *   Added comprehensive unit tests for `OptionalAuth` middleware,
        `AnonymousResultCacheService`, and relevant parts of `QuizHandler`
        to ensure correct behavior under various scenarios for both
        user types.

These changes enhance service accessibility by allowing guest participation while preserving and preparing for extended personalized features for registered users.