### PR TITLE
feat: Implement initial data seeder for categories, sub-categories, a…

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,34 @@ embedding:
     model: nomic-embed-text
 ```
 
+## Command-Line Tools
+
+This section describes various command-line tools available in the project.
+
+### Initial Data Seeder
+
+This tool is used to populate the database with an initial set of categories, sub-categories, and quizzes. This is useful for setting up a new environment or for testing purposes.
+
+**Location of the seeder command:**
+`cmd/seed_initial_data/main.go`
+
+**Location of the seed data file:**
+`configs/seed_data/initial_english_quizzes.json`
+
+**How to run the seeder:**
+
+1.  Ensure your database is running and accessible as per the `config.yaml` settings.
+2.  Make sure database migrations have been applied:
+    ```bash
+    go run cmd/migrate/main.go
+    ```
+3.  Run the seeder command from the root of the project:
+    ```bash
+    go run cmd/seed_initial_data/main.go
+    ```
+
+The command will log its progress to the console. It is designed to be idempotent for categories and sub-categories: it will not create duplicate categories (by name) or duplicate sub-categories (by name, within the same parent category). Quizzes are always added as new items under their respective sub-categories each time the seeder processes that sub-category; it does not check for duplicate quizzes by content.
+
 ## API Endpoints
 
 ### Authentication

--- a/cmd/seed_initial_data/internal/seedmodels/seed_models.go
+++ b/cmd/seed_initial_data/internal/seedmodels/seed_models.go
@@ -1,0 +1,23 @@
+package seedmodels
+
+// SeedQuiz defines the structure for a quiz item in the JSON seed file.
+type SeedQuiz struct {
+	Question     string   `json:"question"`
+	ModelAnswers []string `json:"model_answers"`
+	Keywords     []string `json:"keywords"`
+	Difficulty   string   `json:"difficulty"`
+}
+
+// SeedSubCategory defines the structure for a sub-category in the JSON seed file.
+type SeedSubCategory struct {
+	Name        string     `json:"sub_category_name"`
+	Description string     `json:"sub_category_description"`
+	Quizzes     []SeedQuiz `json:"quizzes"`
+}
+
+// SeedCategory defines the structure for a category in the JSON seed file.
+type SeedCategory struct {
+	Name        string            `json:"category_name"`
+	Description string            `json:"category_description"`
+	SubCategories []SeedSubCategory `json:"sub_categories"`
+}

--- a/cmd/seed_initial_data/main.go
+++ b/cmd/seed_initial_data/main.go
@@ -1,0 +1,161 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"quiz-byte/cmd/seed_initial_data/internal/seedmodels"
+	"quiz-byte/internal/config"
+	"quiz-byte/internal/database"
+	"quiz-byte/internal/domain"
+	"quiz-byte/internal/logger"
+	"quiz-byte/internal/repository"
+
+	"github.com/jmoiron/sqlx"
+	"go.uber.org/zap"
+)
+
+const (
+	seedFilePath = "configs/seed_data/initial_english_quizzes.json"
+)
+
+func firstN(s string, n int) string {
+	if len(s) < n {
+		return s
+	}
+	return s[:n]
+}
+
+func main() {
+	ctx := context.Background()
+	cfg, err := config.LoadConfig()
+	if err != nil {
+		// If logger is not initialized yet, use fmt
+		fmt.Printf("Failed to load configuration: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Initialize logger
+	// Assuming cfg.Logger is the correct field for logger configuration
+	if err := logger.Initialize(&cfg.Logger); err != nil {
+		fmt.Printf("Failed to initialize logger: %v\n", err)
+		os.Exit(1)
+	}
+	defer logger.Sync() // Ensure logs are flushed
+	log := logger.Get()
+
+	log.Info("Starting initial data seeding process...")
+	db, err := database.NewSQLXOracleDB(cfg.GetDSN())
+	if err != nil {
+		log.Fatal("Failed to connect to Oracle database", zap.Error(err))
+	}
+	defer db.Close()
+	log.Info("Successfully connected to Oracle database.")
+
+	log.Info("Loading seed data from file", zap.String("path", seedFilePath))
+	byteValue, err := os.ReadFile(seedFilePath)
+	if err != nil {
+		log.Fatal("Failed to read seed file", zap.String("path", seedFilePath), zap.Error(err))
+	}
+
+	var seedCategories []seedmodels.SeedCategory
+	if err := json.Unmarshal(byteValue, &seedCategories); err != nil {
+		log.Fatal("Failed to unmarshal seed data", zap.Error(err))
+	}
+	log.Info("Successfully unmarshalled seed data", zap.Int("categories_loaded", len(seedCategories)))
+
+	for _, sc := range seedCategories {
+		err := seedCategoryData(ctx, db, log, sc)
+		if err != nil {
+			log.Error("Error seeding category, transaction rolled back", zap.String("category", sc.Name), zap.Error(err))
+			// Decide if you want to stop on first error or continue with other categories
+		}
+	}
+	log.Info("Initial data seeding process completed.")
+}
+
+func seedCategoryData(
+	ctx context.Context,
+	db *sqlx.DB, // The seeder uses the main DB connection to start a transaction
+	log *zap.Logger,
+	seedCat seedmodels.SeedCategory,
+) (err error) { // Named return for clarity in defer
+	log.Info("Processing category", zap.String("name", seedCat.Name))
+	tx, err := db.BeginTxx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("failed to begin transaction for category %s: %w", seedCat.Name, err)
+	}
+	// Defer a function to handle transaction rollback or commit
+	defer func() {
+		if p := recover(); p != nil {
+			_ = tx.Rollback() // Attempt to rollback on panic
+			panic(p)          // Re-panic after rollback attempt
+		} else if err != nil {
+			log.Error("Rolling back transaction due to error", zap.Error(err), zap.String("category_name_rb", seedCat.Name))
+			if rbErr := tx.Rollback(); rbErr != nil {
+				log.Error("Failed to rollback transaction", zap.Error(rbErr))
+				// Optionally, you could wrap rbErr into the original err: err = fmt.Errorf("%w; additionally, rollback failed: %v", err, rbErr)
+			}
+		} else {
+			// Commit the transaction if no error occurred
+			if cErr := tx.Commit(); cErr != nil {
+				log.Error("Failed to commit transaction", zap.Error(cErr))
+				err = cErr // Set err so the calling function knows about the commit failure
+			} else {
+				log.Info("Successfully committed transaction for category", zap.String("name", seedCat.Name))
+			}
+		}
+	}()
+
+	// Repositories are created with the transaction object (tx which implements DBTX)
+	txCategoryRepo := repository.NewCategoryDatabaseAdapter(tx)
+	txQuizRepo := repository.NewQuizDatabaseAdapter(tx)
+
+	// Check if category exists
+	dbCategory, err := txCategoryRepo.GetByName(ctx, seedCat.Name)
+	if err != nil {
+		return fmt.Errorf("error checking category %s: %w", seedCat.Name, err) // Propagate error to trigger rollback
+	}
+	if dbCategory == nil {
+		log.Info("Category not found, creating.", zap.String("name", seedCat.Name))
+		dbCategory = domain.NewCategory(seedCat.Name, seedCat.Description)
+		if err = txCategoryRepo.SaveCategory(ctx, dbCategory); err != nil {
+			return fmt.Errorf("failed to save category %s: %w", seedCat.Name, err) // Propagate error
+		}
+		log.Info("Created category.", zap.String("id", dbCategory.ID), zap.String("name", dbCategory.Name))
+	} else {
+		log.Info("Category exists.", zap.String("id", dbCategory.ID), zap.String("name", dbCategory.Name))
+	}
+
+	for _, seedSubCat := range seedCat.SubCategories {
+		log.Info("Processing sub-category", zap.String("name", seedSubCat.Name), zap.String("parent_category", dbCategory.Name))
+		dbSubCategory, errSub := txCategoryRepo.GetByNameAndCategoryID(ctx, seedSubCat.Name, dbCategory.ID)
+		if errSub != nil {
+			return fmt.Errorf("error checking sub-category %s: %w", seedSubCat.Name, errSub) // Propagate error
+		}
+		if dbSubCategory == nil {
+			log.Info("Sub-category not found, creating.", zap.String("name", seedSubCat.Name))
+			dbSubCategory = domain.NewSubCategory(dbCategory.ID, seedSubCat.Name, seedSubCat.Description)
+			if errSub = txCategoryRepo.SaveSubCategory(ctx, dbSubCategory); errSub != nil {
+				return fmt.Errorf("failed to save sub-category %s: %w", seedSubCat.Name, errSub) // Propagate error
+			}
+			log.Info("Created sub-category.", zap.String("id", dbSubCategory.ID), zap.String("name", dbSubCategory.Name))
+		} else {
+			log.Info("Sub-category exists.", zap.String("id", dbSubCategory.ID), zap.String("name", dbSubCategory.Name))
+		}
+
+		for _, seedQuiz := range seedSubCat.Quizzes {
+			log.Info("Processing quiz", zap.String("question_preview", firstN(seedQuiz.Question, 20)), zap.String("parent_sub_category", dbSubCategory.Name))
+			difficultyInt := domain.DifficultyToInt(seedQuiz.Difficulty)
+			// Assuming NewQuiz returns *domain.Quiz
+			domainQuiz := domain.NewQuiz(seedQuiz.Question, seedQuiz.ModelAnswers, seedQuiz.Keywords, difficultyInt, dbSubCategory.ID)
+			if errQ := txQuizRepo.SaveQuiz(ctx, domainQuiz); errQ != nil {
+				return fmt.Errorf("failed to save quiz '%s': %w", firstN(seedQuiz.Question, 50), errQ) // Propagate error
+			}
+			log.Info("Successfully created quiz.", zap.String("id", domainQuiz.ID)) // ID should be populated by SaveQuiz
+		}
+	}
+	return nil // Mark success for commit
+}

--- a/configs/seed_data/initial_english_quizzes.json
+++ b/configs/seed_data/initial_english_quizzes.json
@@ -1,0 +1,66 @@
+[
+  {
+    "category_name": "Fundamentals of Computer Science",
+    "category_description": "Basic concepts and theories in computer science.",
+    "sub_categories": [
+      {
+        "sub_category_name": "Data Structures",
+        "sub_category_description": "Covers fundamental data structures.",
+        "quizzes": [
+          {
+            "question": "What is a linked list and what is one advantage it has over an array?",
+            "model_answers": [
+              "A linked list is a linear data structure where elements are not stored at contiguous memory locations but are linked using pointers. An advantage over an array is dynamic size, as it can grow or shrink during runtime without needing to reallocate the entire structure.",
+              "It's a sequence of nodes, each containing data and a reference (or link) to the next node. Unlike arrays, linked lists allow for efficient insertion or deletion of elements from any part of the list without reorganizing all other elements."
+            ],
+            "keywords": ["linked list", "data structure", "dynamic size", "pointers", "nodes", "insertion", "deletion"],
+            "difficulty": "easy"
+          },
+          {
+            "question": "Explain the concept of Big O notation and why it is important in algorithm analysis.",
+            "model_answers": [
+              "Big O notation is a mathematical notation that describes the limiting behavior of a function when the argument tends towards a particular value or infinity. In computer science, it's used to classify algorithms according to how their run time or space requirements grow as the input size grows. It's important because it helps in comparing the efficiency of different algorithms and choosing the most suitable one for a given problem, especially for large datasets."
+            ],
+            "keywords": ["big o notation", "algorithm analysis", "time complexity", "space complexity", "asymptotic analysis", "efficiency"],
+            "difficulty": "medium"
+          }
+        ]
+      },
+      {
+        "sub_category_name": "Basic Algorithms",
+        "sub_category_description": "Fundamental algorithms and problem-solving techniques.",
+        "quizzes": [
+          {
+            "question": "Describe the binary search algorithm. What is its time complexity and a key prerequisite for its use?",
+            "model_answers": [
+              "Binary search is an efficient algorithm for finding an item from a sorted list of items. It works by repeatedly dividing in half the portion of the list that could contain the item, until you've narrowed down the possible locations to just one. Its time complexity is O(log n). A key prerequisite is that the list must be sorted."
+            ],
+            "keywords": ["binary search", "algorithm", "sorted list", "divide and conquer", "logarithmic time complexity", "O(log n)"],
+            "difficulty": "easy"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "category_name": "Software Development Principles",
+    "category_description": "Core principles and practices in software development.",
+    "sub_categories": [
+      {
+        "sub_category_name": "Version Control with Git",
+        "sub_category_description": "Understanding and using Git for version control.",
+        "quizzes": [
+          {
+            "question": "What is a 'merge conflict' in Git and how can it typically be resolved?",
+            "model_answers": [
+              "A merge conflict in Git occurs when Git is unable to automatically resolve differences in code between two commits being merged. This usually happens when the same lines of code are changed in different branches or when one branch deletes a file that another branch has modified. To resolve it, you typically need to manually edit the conflicted files to select the desired changes, then mark the conflict as resolved (e.g., using 'git add' on the affected files), and finally complete the merge.",
+              "It's when changes from different branches affect the same part of a file, and Git can't figure out which change to accept. You have to manually open the file, look for the conflict markers (<<<<<<<, =======, >>>>>>>), decide what the code should look like, remove the markers, and then commit the resolved file."
+            ],
+            "keywords": ["git", "merge conflict", "version control", "branches", "resolve conflict", "manual edit"],
+            "difficulty": "medium"
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/internal/domain/service.go
+++ b/internal/domain/service.go
@@ -27,34 +27,37 @@ type QuizService interface {
 
 // QuizRepository defines the interface for quiz persistence
 type QuizRepository interface {
-	GetQuizByID(id string) (*Quiz, error)
-	GetRandomQuiz() (*Quiz, error)
-	GetRandomQuizBySubCategory(subCategory string) (*Quiz, error)
-	GetSimilarQuiz(quizID string) (*Quiz, error)
+	GetQuizByID(ctx context.Context, id string) (*Quiz, error)
+	GetRandomQuiz(ctx context.Context) (*Quiz, error)
+	GetRandomQuizBySubCategory(ctx context.Context, subCategory string) (*Quiz, error)
+	GetSimilarQuiz(ctx context.Context, quizID string) (*Quiz, error)
 	GetAllSubCategories(ctx context.Context) ([]string, error)
-	SaveAnswer(answer *Answer) error // Assuming SaveAnswer might also need context later, but not in scope for this change
+	SaveAnswer(ctx context.Context, answer *Answer) error
 	SaveQuiz(ctx context.Context, quiz *Quiz) error
-	GetQuizzesByCriteria(SubCategoryID string, limit int) ([]*Quiz, error)
-	GetSubCategoryIDByName(name string) (string, error)
+	GetQuizzesByCriteria(ctx context.Context, SubCategoryID string, limit int) ([]*Quiz, error)
+	GetSubCategoryIDByName(ctx context.Context, name string) (string, error)
 	GetQuizzesBySubCategory(ctx context.Context, subCategoryID string) ([]*Quiz, error)
 	// Methods from internal/domain/quiz.go
-	UpdateQuiz(quiz *Quiz) error
-	SaveQuizEvaluation(evaluation *QuizEvaluation) error
-	GetQuizEvaluation(quizID string) (*QuizEvaluation, error)
+	UpdateQuiz(ctx context.Context, quiz *Quiz) error
+	SaveQuizEvaluation(ctx context.Context, evaluation *QuizEvaluation) error
+	GetQuizEvaluation(ctx context.Context, quizID string) (*QuizEvaluation, error)
 	GetUnattemptedQuizzesWithDetails(ctx context.Context, userID string, limit int, optionalSubCategoryID string) ([]dto.QuizRecommendationItem, error)
 }
 
 // CategoryRepository defines the interface for category persistence
 type CategoryRepository interface {
 	// GetAllCategories returns all categories
-	GetAllCategories() ([]*Category, error)
+	GetAllCategories(ctx context.Context) ([]*Category, error)
 
 	// GetSubCategories returns all subcategories for a given category
-	GetSubCategories(categoryID string) ([]*SubCategory, error)
+	GetSubCategories(ctx context.Context, categoryID string) ([]*SubCategory, error)
 
 	// SaveCategory persists a new category
-	SaveCategory(category *Category) error
+	SaveCategory(ctx context.Context, category *Category) error
 
 	// SaveSubCategory persists a new subcategory
-	SaveSubCategory(subCategory *SubCategory) error
+	SaveSubCategory(ctx context.Context, subCategory *SubCategory) error
+
+	GetByName(ctx context.Context, name string) (*Category, error)
+	GetByNameAndCategoryID(ctx context.Context, name string, categoryID string) (*SubCategory, error)
 }

--- a/internal/repository/category_database_adapter.go
+++ b/internal/repository/category_database_adapter.go
@@ -1,29 +1,29 @@
 package repository
 
 import (
+	"context"
 	"database/sql"
+	"fmt"
 	"quiz-byte/internal/domain"
 	"quiz-byte/internal/repository/models"
 	"quiz-byte/internal/util"
 	"time"
-
-	"github.com/jmoiron/sqlx"
 )
 
 type CategoryDatabaseAdapter struct {
-	db *sqlx.DB
+	db DBTX
 }
 
 // NewCategoryDatabaseAdapter creates a new instance of CategoryDatabaseAdapter
-func NewCategoryDatabaseAdapter(db *sqlx.DB) domain.CategoryRepository {
+func NewCategoryDatabaseAdapter(db DBTX) domain.CategoryRepository {
 	return &CategoryDatabaseAdapter{db: db}
 }
 
 // GetAllCategories returns all categories
-func (r *CategoryDatabaseAdapter) GetAllCategories() ([]*domain.Category, error) {
+func (r *CategoryDatabaseAdapter) GetAllCategories(ctx context.Context) ([]*domain.Category, error) {
 	var categories []models.Category
 	query := "SELECT id, name, description, created_at, updated_at, deleted_at FROM categories WHERE deleted_at IS NULL"
-	err := r.db.Select(&categories, query)
+	err := r.db.SelectContext(ctx, &categories, query)
 	if err != nil {
 		if err == sql.ErrNoRows {
 			return []*domain.Category{}, nil
@@ -39,10 +39,10 @@ func (r *CategoryDatabaseAdapter) GetAllCategories() ([]*domain.Category, error)
 }
 
 // GetSubCategories returns all subcategories for a given category
-func (r *CategoryDatabaseAdapter) GetSubCategories(categoryID string) ([]*domain.SubCategory, error) {
+func (r *CategoryDatabaseAdapter) GetSubCategories(ctx context.Context, categoryID string) ([]*domain.SubCategory, error) {
 	var subCategories []models.SubCategory
-	query := "SELECT id, category_id, name, description, created_at, updated_at, deleted_at FROM sub_categories WHERE category_id = $1 AND deleted_at IS NULL"
-	err := r.db.Select(&subCategories, query, categoryID)
+	query := "SELECT id, category_id, name, description, created_at, updated_at, deleted_at FROM sub_categories WHERE category_id = :1 AND deleted_at IS NULL"
+	err := r.db.SelectContext(ctx, &subCategories, query, categoryID)
 	if err != nil {
 		if err == sql.ErrNoRows {
 			return []*domain.SubCategory{}, nil
@@ -58,7 +58,7 @@ func (r *CategoryDatabaseAdapter) GetSubCategories(categoryID string) ([]*domain
 }
 
 // SaveCategory persists a new category
-func (r *CategoryDatabaseAdapter) SaveCategory(category *domain.Category) error {
+func (r *CategoryDatabaseAdapter) SaveCategory(ctx context.Context, category *domain.Category) error {
 	modelCategory := convertToModelCategory(category)
 	modelCategory.ID = util.NewULID()
 	modelCategory.CreatedAt = time.Now()
@@ -66,7 +66,7 @@ func (r *CategoryDatabaseAdapter) SaveCategory(category *domain.Category) error 
 
 	query := `INSERT INTO categories (id, name, description, created_at, updated_at)
               VALUES (:id, :name, :description, :created_at, :updated_at)`
-	_, err := r.db.NamedExec(query, modelCategory)
+	_, err := r.db.NamedExecContext(ctx, query, modelCategory)
 	if err != nil {
 		return err
 	}
@@ -77,7 +77,7 @@ func (r *CategoryDatabaseAdapter) SaveCategory(category *domain.Category) error 
 }
 
 // SaveSubCategory persists a new subcategory
-func (r *CategoryDatabaseAdapter) SaveSubCategory(subCategory *domain.SubCategory) error {
+func (r *CategoryDatabaseAdapter) SaveSubCategory(ctx context.Context, subCategory *domain.SubCategory) error {
 	modelSubCategory := convertToModelSubCategory(subCategory)
 	modelSubCategory.ID = util.NewULID()
 	modelSubCategory.CreatedAt = time.Now()
@@ -85,7 +85,7 @@ func (r *CategoryDatabaseAdapter) SaveSubCategory(subCategory *domain.SubCategor
 
 	query := `INSERT INTO sub_categories (id, category_id, name, description, created_at, updated_at)
               VALUES (:id, :category_id, :name, :description, :created_at, :updated_at)`
-	_, err := r.db.NamedExec(query, modelSubCategory)
+	_, err := r.db.NamedExecContext(ctx, query, modelSubCategory)
 	if err != nil {
 		return err
 	}
@@ -93,6 +93,37 @@ func (r *CategoryDatabaseAdapter) SaveSubCategory(subCategory *domain.SubCategor
 	subCategory.CreatedAt = modelSubCategory.CreatedAt
 	subCategory.UpdatedAt = modelSubCategory.UpdatedAt
 	return nil
+}
+
+// GetByName retrieves a category by its name.
+// It returns (nil, nil) if the category is not found.
+func (r *CategoryDatabaseAdapter) GetByName(ctx context.Context, name string) (*domain.Category, error) {
+	var category models.Category
+	// Using NamedArg for Oracle compatibility if needed, otherwise :name or $1 depending on driver
+	query := "SELECT id, name, description, created_at, updated_at FROM categories WHERE name = :1 AND deleted_at IS NULL"
+	err := r.db.GetContext(ctx, &category, query, name) // Use GetContext for context propagation
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, nil // Not found is not an application error here
+		}
+		return nil, fmt.Errorf("error fetching category by name %s: %w", name, err)
+	}
+	return convertToDomainCategory(&category), nil
+}
+
+// GetByNameAndCategoryID retrieves a subcategory by its name and parent category ID.
+// It returns (nil, nil) if the subcategory is not found.
+func (r *CategoryDatabaseAdapter) GetByNameAndCategoryID(ctx context.Context, name string, categoryID string) (*domain.SubCategory, error) {
+	var subCategory models.SubCategory
+	query := "SELECT id, category_id, name, description, created_at, updated_at FROM sub_categories WHERE name = :1 AND category_id = :2 AND deleted_at IS NULL"
+	err := r.db.GetContext(ctx, &subCategory, query, name, categoryID) // Use GetContext
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, nil // Not found
+		}
+		return nil, fmt.Errorf("error fetching subcategory by name %s and categoryID %s: %w", name, categoryID, err)
+	}
+	return convertToDomainSubCategory(&subCategory), nil
 }
 
 // Helper functions for converting between domain and model types

--- a/internal/repository/repository.go
+++ b/internal/repository/repository.go
@@ -1,0 +1,16 @@
+package repository
+
+import (
+	"context"
+	"database/sql" // Required for sql.Result
+	"github.com/jmoiron/sqlx"
+)
+
+// DBTX is an interface abstracting *sqlx.DB and *sqlx.Tx for repository use.
+type DBTX interface {
+	GetContext(ctx context.Context, dest interface{}, query string, args ...interface{}) error
+	SelectContext(ctx context.Context, dest interface{}, query string, args ...interface{}) error
+	NamedExecContext(ctx context.Context, query string, arg interface{}) (sql.Result, error)
+	ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error)
+	NamedQueryContext(ctx context.Context, query string, arg interface{}) (*sqlx.Rows, error)
+}

--- a/internal/service/answer_cache.go
+++ b/internal/service/answer_cache.go
@@ -141,7 +141,7 @@ func (s *answerCacheServiceImpl) GetAnswerFromCache(ctx context.Context, quizID 
 				zap.String("cachedUserAnswer", cachedEntry.UserAnswer))
 
 			if s.repo != nil {
-				quizForModelAnswer, errRepo := s.repo.GetQuizByID(quizID)
+				quizForModelAnswer, errRepo := s.repo.GetQuizByID(ctx, quizID) // Added ctx
 				if errRepo != nil {
 					logger.Get().Error("AnswerCacheService: Failed to get quiz by ID for updating model answer in cache hit",
 						zap.Error(errRepo),

--- a/internal/service/quiz.go
+++ b/internal/service/quiz.go
@@ -77,7 +77,8 @@ func NewQuizService(
 
 // GetRandomQuiz implements QuizService
 func (s *quizService) GetRandomQuiz(subCategory string) (*dto.QuizResponse, error) {
-	quiz, err := s.repo.GetRandomQuiz()
+	ctx := context.Background() // Added context
+	quiz, err := s.repo.GetRandomQuiz(ctx)
 	if err != nil {
 		return nil, domain.NewInternalError("Failed to get random quiz", err)
 	}
@@ -142,7 +143,7 @@ func (s *quizService) CheckAnswer(req *dto.CheckAnswerRequest) (*dto.CheckAnswer
 	res, sfErr, _ := s.sfGroup.Do(sfKey, func() (interface{}, error) {
 		logger.Get().Debug("Calling singleflight Do func for CheckAnswer", zap.String("sfKey", sfKey))
 
-		quiz, err := s.repo.GetQuizByID(req.QuizID)
+		quiz, err := s.repo.GetQuizByID(ctx, req.QuizID) // Added ctx
 		if err != nil {
 			return nil, domain.NewInternalError("Failed to get quiz", err)
 		}
@@ -237,7 +238,7 @@ func (s *quizService) GetAllSubCategories() ([]string, error) {
 	// Cache Miss or error during cache read: Use singleflight
 	res, sfErr, _ := s.sfGroup.Do(cacheKey, func() (interface{}, error) {
 		logger.Get().Debug("Calling singleflight Do func for GetAllSubCategories", zap.String("cacheKey", cacheKey))
-		categories, err := s.repo.GetAllSubCategories(ctx)
+		categories, err := s.repo.GetAllSubCategories(ctx) // ctx is already available in this scope
 		if err != nil {
 			return nil, domain.NewInternalError("Failed to get subcategories", err)
 		}
@@ -283,7 +284,7 @@ func (s *quizService) GetBulkQuizzes(req *dto.BulkQuizzesRequest) (*dto.BulkQuiz
 	}
 
 	// Get subcategory ID using case-insensitive comparison
-	subCategoryID, err := s.repo.GetSubCategoryIDByName(req.SubCategory)
+	subCategoryID, err := s.repo.GetSubCategoryIDByName(ctx, req.SubCategory) // Added ctx
 	if err != nil {
 		return nil, domain.NewInternalError("Failed to get subcategory ID", err)
 	}
@@ -320,7 +321,7 @@ func (s *quizService) GetBulkQuizzes(req *dto.BulkQuizzesRequest) (*dto.BulkQuiz
 	// Cache Miss or error: Use singleflight
 	res, sfErr, _ := s.sfGroup.Do(cacheKey, func() (interface{}, error) {
 		logger.Get().Debug("Calling singleflight Do func for GetBulkQuizzes", zap.String("cacheKey", cacheKey))
-		domainQuizzes, err := s.repo.GetQuizzesByCriteria(subCategoryID, req.Count)
+		domainQuizzes, err := s.repo.GetQuizzesByCriteria(ctx, subCategoryID, req.Count) // Added ctx
 		if err != nil {
 			return nil, domain.NewInternalError("Failed to get bulk quizzes from repository", err)
 		}

--- a/internal/service/user_service.go
+++ b/internal/service/user_service.go
@@ -125,7 +125,7 @@ func (s *userServiceImpl) GetUserQuizAttempts(ctx context.Context, userID string
 
 	attemptItems := make([]dto.UserQuizAttemptItem, len(domainAttempts))
 	for i, attempt := range domainAttempts { // attempt is domain.UserQuizAttempt
-		quiz, errQuiz := s.quizRepo.GetQuizByID(attempt.QuizID)
+		quiz, errQuiz := s.quizRepo.GetQuizByID(ctx, attempt.QuizID) // Added ctx
 		if errQuiz != nil || quiz == nil {
 			if quiz == nil && errQuiz == nil {
 				return nil, fmt.Errorf("%w: quiz_id %s for attempt_id %s (quiz not found)", ErrQuizDetailNotFound, attempt.QuizID, attempt.ID)
@@ -193,7 +193,7 @@ func (s *userServiceImpl) GetUserIncorrectAnswers(ctx context.Context, userID st
 
 	incorrectAnswerItems := make([]dto.UserIncorrectAnswerItem, len(domainAttempts))
 	for i, attempt := range domainAttempts { // attempt is domain.UserQuizAttempt
-		quiz, errQuiz := s.quizRepo.GetQuizByID(attempt.QuizID)
+		quiz, errQuiz := s.quizRepo.GetQuizByID(ctx, attempt.QuizID) // Added ctx
 		if errQuiz != nil || quiz == nil {
 			if quiz == nil && errQuiz == nil {
 				return nil, fmt.Errorf("%w: quiz_id %s for attempt_id %s (quiz not found)", ErrQuizDetailNotFound, attempt.QuizID, attempt.ID)


### PR DESCRIPTION
…nd quizzes

This commit introduces a new command-line tool for seeding the database with initial quiz content.

The seeder (`cmd/seed_initial_data/main.go`) reads data from a JSON file (`configs/seed_data/initial_english_quizzes.json`) and populates the database with categories, sub-categories, and quizzes.

Key features and changes:
- Defines a JSON structure for seed data.
- Implements idempotent creation for categories (by name) and sub-categories (by name within a parent category). Quizzes are always added as new items.
- Uses database transactions for each top-level category and its associated sub-categories and quizzes to ensure data consistency.
- Introduces a `DBTX` interface (`internal/repository/repository.go`) to allow repository adapters to work with both `*sqlx.DB` and `*sqlx.Tx`.
- Refactors `CategoryDatabaseAdapter` and `QuizDatabaseAdapter` constructors and internal `db` fields to use the `DBTX` interface.
- Makes methods in `QuizDatabaseAdapter` and the `QuizRepository` interface context-aware, accepting `context.Context`.
- Adds new repository methods: `CategoryRepository.GetByName` and `CategoryRepository.GetByNameAndCategoryID`.
- Includes a sample seed data file with a few entries.
- Updates `README.md` to document the new seeder command.

This functionality allows for easier setup of new environments and provides a baseline dataset for development and testing.